### PR TITLE
Fix: Replace hard coded contributor image with actual image

### DIFF
--- a/src/pages/contributors/contributor-1.adoc
+++ b/src/pages/contributors/contributor-1.adoc
@@ -8,7 +8,7 @@
 :page-pronouns: They/them
 :page-location: San Francisco, CA, USA
 :page-firstcommit: June 2018
-:page-featured: true
+:page-featured: false
 :page-intro: Sarah Jenkins is a passionate open-source enthusiast with a knack for streamlining software development processes. Hailing from the bustling tech hub of Silicon Valley, Sarah's journey into the world of Jenkins began with a simple curiosity that soon evolved into an unwavering commitment to the project.
 
 With a degree in Computer Science from Stanford University, Sarah possesses a strong technical foundation. Her day job as a DevOps engineer at a leading tech company provides her with real-world insights into the challenges developers face. She seamlessly blends her professional expertise with her fervor for open-source collaboration.

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -17,7 +17,7 @@ const IndexPage = (props) => {
         >
           <Box>
             <img
-              src={"avatar/stephanie-liverani-Zz5LQe-VSMY-unsplash.jpg"}
+              src={contributor.node.pageAttributes.image}
               alt={"Contributor avatar"}
               width={250}
               height={250}
@@ -105,7 +105,7 @@ const IndexPage = (props) => {
                   paddingLeft={2}
                   paddingRight={2}
                 >
-                  <img src={"avatar/stephanie-liverani-Zz5LQe-VSMY-unsplash.jpg"}
+                  <img src={contributor.node.pageAttributes.image}
                        alt={"Featured contributor avatar"}
                        width={350}
                        height={350}


### PR DESCRIPTION
## Tasks completed
1. Replace hard coded contributor image with actual image indicated on .adoc. 
2. Make only one featured contributor for now.

c.c. @kmartens27 