### PR TITLE
chore: replace heavy placeholder avatar by buttlers

### DIFF
--- a/src/pages/contributors/contributor-1.adoc
+++ b/src/pages/contributors/contributor-1.adoc
@@ -4,7 +4,7 @@
 :page-twitter: sarahjenkins
 :page-github: sarah-jenkins
 :page-email: sarah.jenkins@cloudbees.com
-:page-image: avatar/stephanie-liverani-Zz5LQe-VSMY-unsplash.jpg
+:page-image: https://www.jenkins.io/images/logos/duchess/256.png
 :page-pronouns: They/them
 :page-location: San Francisco, CA, USA
 :page-firstcommit: June 2018

--- a/src/pages/contributors/contributor-2.adoc
+++ b/src/pages/contributors/contributor-2.adoc
@@ -4,7 +4,7 @@
 :page-twitter: rebeccajenkins
 :page-github: rebecca-jenkins
 :page-email: rebecca.jenkins@cloudbees.com
-:page-image: avatar/stephanie-liverani-Zz5LQe-VSMY-unsplash.jpg
+:page-image: https://www.jenkins.io/images/logos/chatterbox/256.png
 :page-pronouns: They/them
 :page-location: San Francisco, CA, USA
 :page-firstcommit: June 2018

--- a/src/pages/contributors/contributor-3.adoc
+++ b/src/pages/contributors/contributor-3.adoc
@@ -4,7 +4,7 @@
 :page-twitter: tonyjenkins
 :page-github: tony-jenkins
 :page-email: tony.jenkins@cloudbees.com
-:page-image: avatar/stephanie-liverani-Zz5LQe-VSMY-unsplash.jpg
+:page-image: https://www.jenkins.io/images/logos/actor/256.png
 :page-pronouns: They/them
 :page-location: San Francisco, CA, USA
 :page-firstcommit: June 2018

--- a/src/pages/contributors/contributor-4.adoc
+++ b/src/pages/contributors/contributor-4.adoc
@@ -4,7 +4,7 @@
 :page-twitter: markjenkins
 :page-github:
 :page-email:
-:page-image: avatar/stephanie-liverani-Zz5LQe-VSMY-unsplash.jpg
+:page-image: https://www.jenkins.io/images/logos/worldwide/256.png
 :page-pronouns: They/them
 :page-location: San Francisco, CA, USA
 :page-firstcommit: June 2018


### PR DESCRIPTION
This PR replaces the heavy picture (almost 3Mio) used as avatar for the placeholders by some Buttler artworks, until a proper placeholder is ready and/or removed.

Related (but not resolving): 
- #21 