### PR TITLE
chore: switch README to asciidoc and add a link to the website

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,6 +1,6 @@
 # Jenkins Contributor Spotlight
 
-This feature is to showcase the top contributors of the Jenkins project.
+This feature is to showcase the top contributors of the Jenkins project at link:https://contributors.jenkins.io[contributors.jenkins.io]
 
 ## 🚀 Quick start
 


### PR DESCRIPTION
This PR switches the README to asciidoc like the rest of the content, and adds a link to contributors.jenkins.io

Note: I've also set the site as URL of the repo in its short description.