### PR TITLE
fixup: store buttler avatars

### DIFF
--- a/src/pages/contributors/contributor-1.adoc
+++ b/src/pages/contributors/contributor-1.adoc
@@ -4,7 +4,7 @@
 :page-twitter: sarahjenkins
 :page-github: sarah-jenkins
 :page-email: sarah.jenkins@cloudbees.com
-:page-image: https://www.jenkins.io/images/logos/duchess/256.png
+:page-image: avatar/buttler_duchess.png
 :page-pronouns: They/them
 :page-location: San Francisco, CA, USA
 :page-firstcommit: June 2018

--- a/src/pages/contributors/contributor-2.adoc
+++ b/src/pages/contributors/contributor-2.adoc
@@ -4,7 +4,7 @@
 :page-twitter: rebeccajenkins
 :page-github: rebecca-jenkins
 :page-email: rebecca.jenkins@cloudbees.com
-:page-image: https://www.jenkins.io/images/logos/chatterbox/256.png
+:page-image: avatar/buttler_chatterbox.png
 :page-pronouns: They/them
 :page-location: San Francisco, CA, USA
 :page-firstcommit: June 2018

--- a/src/pages/contributors/contributor-3.adoc
+++ b/src/pages/contributors/contributor-3.adoc
@@ -4,7 +4,7 @@
 :page-twitter: tonyjenkins
 :page-github: tony-jenkins
 :page-email: tony.jenkins@cloudbees.com
-:page-image: https://www.jenkins.io/images/logos/actor/256.png
+:page-image: avatar/buttler_actor.png
 :page-pronouns: They/them
 :page-location: San Francisco, CA, USA
 :page-firstcommit: June 2018

--- a/src/pages/contributors/contributor-4.adoc
+++ b/src/pages/contributors/contributor-4.adoc
@@ -4,7 +4,7 @@
 :page-twitter: markjenkins
 :page-github:
 :page-email:
-:page-image: https://www.jenkins.io/images/logos/worldwide/256.png
+:page-image: avatar/buttler_worldwide.png
 :page-pronouns: They/them
 :page-location: San Francisco, CA, USA
 :page-firstcommit: June 2018


### PR DESCRIPTION
While absolute URLs were OK on Netlify preview, it's not correctly rendered on production:

```html
<img src="../../../https://www.jenkins.io/images/logos/duchess/256.png" alt="Contributor avatar" width="350" height="350" style="object-fit:cover;border-radius:50%"/>
```

Fixup of:
- #25