### PR TITLE
Fix navbar and footer links with foreign URLs

### DIFF
--- a/gatsby-ssr.jsx
+++ b/gatsby-ssr.jsx
@@ -8,7 +8,7 @@ const HtmlAttributes = {
 const HeadComponents = [
   <React.Fragment key="head-1">
     <script type="module" src="https://unpkg.com/@jenkinsci/jenkins-io-components?module"></script>
-    <jio-navbar></jio-navbar>
+    <jio-navbar property={"https://contributors.jenkins.io"}></jio-navbar>
   </React.Fragment>
 ]
 
@@ -19,7 +19,7 @@ const BodyAttributes = {
 const PostBodyComponents = [
   <React.Fragment key="body-1">
     <script type="module" src="https://unpkg.com/@jenkinsci/jenkins-io-components?module"></script>
-    <jio-footer></jio-footer>
+    <jio-footer property={"https://contributors.jenkins.io"}></jio-footer>
   </React.Fragment>
 ]
 


### PR DESCRIPTION
Without the fix, j.io URLs are resolved against contributors, which is not correct: 
![Screenshot 2023-11-29 at 00 02 29](https://github.com/jenkins-infra/contributor-spotlight/assets/13383509/a2511465-f77a-4d02-b387-654547bb8de3)


