### PR TITLE
fix: remove trailing slash in siteUrl of siteMetadata

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -4,7 +4,7 @@
 module.exports = {
   siteMetadata: {
     title: `Jenkins Contributor Spotlight`,
-    siteUrl: `https://www.jenkins.io/`,
+    siteUrl: `https://www.jenkins.io`,
     description: `Jenkins Contributor Spotlight is where we celebrate the contributions of Jenkins community members`,
   },
   plugins: [


### PR DESCRIPTION
Removed trailing slash from siteUrl. 