### PR TITLE
Alex Earl spotlight - changing plugin macro for link macro

### DIFF
--- a/src/pages/contributors/alex-earl.adoc
+++ b/src/pages/contributors/alex-earl.adoc
@@ -20,7 +20,7 @@ When not pursuing his open-source work, Alex loves spending time with his family
 I was doing C++ and Visual Basic at work, along with a little bit of embedded C development.
 I transitioned to C# from C++/VB in the application I was supporting, and started to pick up more responsibility in the build and deployment area of my group.
 I started using Jenkins to do the build/deployment and moved my group in a much more agile direction, using continuous integration for our testing.
-This led to me looking at the plugin:email-ext[Email Extension] plugin and trying to understand why it wasn't able to do what I wanted it to do.
+This led to me looking at the link:https://plugins.jenkins.io/email-ext/[Email Extension] plugin and trying to understand why it wasn't able to do what I wanted it to do.
 I started submitting patches and fixing issues in the plugin to help me in my work.
 The rest, as they say, is history!
 


### PR DESCRIPTION
Currently, Alex Earl's spotlight is set to use a plugin macro, which will not work in this repo at this time. I have updated it to use the link macro so that it leads to the plugin page on plugins.jenkins.io