### PR TITLE
chore: don't add `?`, already included in the `FILESHARE_QUERYSTRING` credentials

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -101,7 +101,7 @@ pipeline {
         ]) {
           sh '''
           npm run build
-          azcopy sync --recursive=true --delete-destination=true ./public/ "https://contributorsjenkinsio.file.core.windows.net/contributors-jenkins-io/?${FILESHARE_QUERYSTRING}"
+          azcopy sync --recursive=true --delete-destination=true ./public/ "https://contributorsjenkinsio.file.core.windows.net/contributors-jenkins-io/${FILESHARE_QUERYSTRING}"
           '''
         }
       }


### PR DESCRIPTION
This PR removes the `?` from the URL used by `azcopy` as it's (now) already included in the credentials, like it's in the corresponding terraform output value.