### PR TITLE
chore: use a short lived File Share SAS token

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -103,8 +103,9 @@ pipeline {
         sh '''
         npm run build
 
-        # Generate a SAS token with 10 minutes expiry date
-        az login --service-principal --user "${STORAGE_APP_CLIENT_ID}" --password "${STORAGE_APP_CLIENT_SECRET}" --tenant "${STORAGE_APP_TENANT_ID}"
+        ## Generate a SAS token with 10 minutes expiry date
+        # Login via the service principal, hiding JSON output from az login
+        az login --service-principal --user "${STORAGE_APP_CLIENT_ID}" --password "${STORAGE_APP_CLIENT_SECRET}" --tenant "${STORAGE_APP_TENANT_ID}" > /dev/null
         expiry=$(date -u -d "$current_date + 10 minutes" +"%Y-%m-%dT%H:%MZ")
         base_url="https://${STORAGE_NAME}.file.core.windows.net/${STORAGE_FILESHARE}"
 


### PR DESCRIPTION
This PR replaces the long lived SAS token by one generated from a service principal.

Follow-up of:
- https://github.com/jenkins-infra/azure/pull/595
- https://github.com/jenkins-infra/kubernetes-management/pull/4894

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/3414