### PR TITLE
chore: use `infra.withFileShareServicePrincipal`

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,3 @@
-@Library('pipeline-library@pull/839/head') _
-
 pipeline {
   options {
     timeout(time: 60, unit: 'MINUTES')
@@ -110,29 +108,6 @@ pipeline {
             # Synchronize the File Share content
             set +x
             azcopy sync --recursive=true --delete-destination=true ./public/ "${FILESHARE_SIGNED_URL}"
-            '''
-          }
-        }
-      }
-    }
-
-    // TODO: to be removed, just here to demonstrate the pipeline library new function in this PR
-    stage('Test of pipeline-library#839') {
-      when {
-        allOf{
-          expression { infra.isInfra() }
-        }
-      }
-      steps {
-        script {
-          infra.withFileShareServicePrincipal([
-            servicePrincipalCredentialsId: 'contributors-jenkins-io-fileshare-service-principal-writer',
-            fileShare: 'contributors-jenkins-io',
-            fileShareStorageAccount: 'contributorsjenkinsio'
-          ]) {
-            sh '''
-            set +x
-            azcopy list "${FILESHARE_SIGNED_URL}"
             '''
           }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,3 +1,5 @@
+@Library('pipeline-library@pull/839/head') _
+
 pipeline {
   options {
     timeout(time: 60, unit: 'MINUTES')
@@ -94,40 +96,46 @@ pipeline {
         NODE_ENV = 'production'
         GATSBY_MATOMO_SITE_URL = 'https://jenkins-matomo.do.g4v.dev'
         GATSBY_MATOMO_SITE_ID = '4'
-        STORAGE_APP = credentials('contributors-jenkins-io-fileshare-service-principal-writer')
-        STORAGE_NAME = "contributorsjenkinsio"
-        STORAGE_FILESHARE = "contributors-jenkins-io"
-        STORAGE_PERMISSIONS = "dlrw"
       }
       steps {
-        sh '''
-        npm run build
+        script {
+          infra.withFileShareServicePrincipal([
+            servicePrincipalCredentialsId: 'contributors-jenkins-io-fileshare-service-principal-writer',
+            fileShare: 'contributors-jenkins-io',
+            fileShareStorageAccount: 'contributorsjenkinsio'
+          ]) {
+            sh '''
+            npm run build
 
-        ## Generate a SAS token with 10 minutes expiry date
-        # Login via the service principal, hiding JSON output from az login
-        az login --service-principal --user "${STORAGE_APP_CLIENT_ID}" --password "${STORAGE_APP_CLIENT_SECRET}" --tenant "${STORAGE_APP_TENANT_ID}" > /dev/null
-        expiry=$(date -u -d "$current_date + 10 minutes" +"%Y-%m-%dT%H:%MZ")
-        base_url="https://${STORAGE_NAME}.file.core.windows.net/${STORAGE_FILESHARE}"
+            # Synchronize the File Share content
+            set +x
+            azcopy sync --recursive=true --delete-destination=true ./public/ "${FILESHARE_SIGNED_URL}"
+            '''
+          }
+        }
+      }
+    }
 
-        # Don't show the command using the token
-        set +x
-        token=$(az storage share generate-sas \
-          --name "${STORAGE_FILESHARE}" \
-          --account-name "${STORAGE_NAME}" \
-          --https-only \
-          --permissions "${STORAGE_PERMISSIONS}" \
-          --expiry "${expiry}" \
-          --only-show-errors)
-        az logout
-        url="${base_url}?$(echo ${token} | sed 's/\"//g')"
-
-        # Synchronize the File Share content
-        echo "INFO: Synchronizing ${base_url}..."
-        azcopy sync --recursive=true --delete-destination=true ./public/ "$url"
-        set +x
-
-        echo 'INFO: deployment completed.'
-        '''
+    // TODO: to be removed, just here to demonstrate the pipeline library new function in this PR
+    stage('Test of pipeline-library#839') {
+      when {
+        allOf{
+          expression { infra.isInfra() }
+        }
+      }
+      steps {
+        script {
+          infra.withFileShareServicePrincipal([
+            servicePrincipalCredentialsId: 'contributors-jenkins-io-fileshare-service-principal-writer',
+            fileShare: 'contributors-jenkins-io',
+            fileShareStorageAccount: 'contributorsjenkinsio'
+          ]) {
+            sh '''
+            set +x
+            azcopy list "${FILESHARE_SIGNED_URL}"
+            '''
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
This PR uses `infra.withFileShareServicePrincipal` shared pipeline library to retrieve the signed file share URL.

Test of:
- https://github.com/jenkins-infra/pipeline-library/pull/839

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/3414