### PR TITLE
chore(build): add `--skip-version-check` to `azcopy` arguments

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -107,7 +107,11 @@ pipeline {
 
             # Synchronize the File Share content
             set +x
-            azcopy sync --recursive=true --delete-destination=true ./public/ "${FILESHARE_SIGNED_URL}"
+            azcopy sync \
+              --skip-version-check \
+              --recursive=true \
+              --delete-destination=true \
+              ./public/ "${FILESHARE_SIGNED_URL}"
             '''
           }
         }


### PR DESCRIPTION
This PR adds `--skip-version-check` to `azcopy` arguments as there is no need for this check here.