### PR TITLE
chore: complete title on contributor page

### DIFF
--- a/src/templates/contributor-details.jsx
+++ b/src/templates/contributor-details.jsx
@@ -16,16 +16,17 @@ function ContributorDetails(props) {
     const isDesktop = useMediaQuery(theme.breakpoints.up('lg'))
     const isTablet = useMediaQuery(theme.breakpoints.between('lg', 'sm'))
     const isMobile = useMediaQuery(theme.breakpoints.down('sm'))
+    const title = props.data.asciidoc.pageAttributes.name + ' - Jenkins Contributor Spotlight'
 
     return (
         <>
             <Helmet>
                 <meta charSet='utf-8' />
-                <title>{props.data.asciidoc.pageAttributes.name}</title>
+                <title>{title}</title>
                 <meta
                     name='title'
                     property='og:title'
-                    content={props.data.asciidoc.pageAttributes.name}
+                    content={title}
                 />
                 <meta
                     property='og:image'


### PR DESCRIPTION
This PR adds ` - Jenkins Contributor Spotlight` after the contributor name in the page title when consulting a contributor page.

Before/After:
<img width="278" alt="image" src="https://github.com/jenkins-infra/contributor-spotlight/assets/91831478/f5fd49fc-b5ea-4f63-abaa-6553b074651d">
