### PR TITLE
chore: remove `typos` installation, already in agents

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,11 +20,7 @@ pipeline {
   stages {
     stage('Check for typos') {
       steps {
-        sh '''
-        curl -qsL https://github.com/crate-ci/typos/releases/download/v1.5.0/typos-v1.5.0-x86_64-unknown-linux-musl.tar.gz | tar xvzf - ./typos
-        curl -qsL https://github.com/halkeye/typos-json-to-checkstyle/releases/download/v0.1.1/typos-checkstyle-v0.1.1-x86_64 > typos-checkstyle && chmod 0755 typos-checkstyle
-        ./typos --format json | ./typos-checkstyle - > checkstyle.xml || true
-        '''
+        sh './typos --format json | ./typos-checkstyle - > checkstyle.xml || true'
       }
       post {
         always {


### PR DESCRIPTION
As `typos` is already installed on agents, this PR removes its downloads and installation from the pipeline.