### PR TITLE
chore(updatecli): retrieve nodejs version from packer-images

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,4 +1,5 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-    "extends": ["config:recommended"]
+    "extends": ["config:recommended"],
+    "ignoreDeps": ["node"]
 }

--- a/Jenkinsfile_updatecli
+++ b/Jenkinsfile_updatecli
@@ -1,0 +1,4 @@
+updatecli(action: 'diff')
+if (env.BRANCH_IS_PRIMARY) {
+    updatecli(action: 'apply', cronTriggerExpression: '@weekly')
+}

--- a/updatecli/updatecli.d/nodejs.yaml
+++ b/updatecli/updatecli.d/nodejs.yaml
@@ -1,0 +1,53 @@
+---
+name: Bump `nodejs` version according to packer-images
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  ciJenkinsIoPackerImageVersion:
+    kind: yaml
+    name: Get the packer-image version deployed on ci.jenkins.io agents
+    spec:
+      file: https://raw.githubusercontent.com/jenkins-infra/jenkins-infra/production/hieradata/common.yaml
+      key: $.profile::jenkinscontroller::jcasc.agent_images.azure_vms_gallery_image.version
+  packerImageNodeVersion:
+    kind: yaml
+    name: Get  the `nodejs_linux_version` set in the deployed packer-image
+    dependson:
+      - ciJenkinsIoPackerImageVersion
+    spec:
+      file: https://raw.githubusercontent.com/jenkins-infra/packer-images/{{ source "ciJenkinsIoPackerImageVersion" }}/provisioning/tools-versions.yml
+      key: $.nodejs_linux_version
+
+targets:
+  updateToolVersions:
+    name: bump `nodejs` version to {{ source "packerImageNodeVersion" }} in .tool-versions
+    sourceid: packerImageNodeVersion
+    kind: file
+    spec:
+      file: .tool-versions
+      matchpattern: >
+        nodejs (.*)
+      replacepattern: >
+        nodejs {{ source "packerImageNodeVersion" }}
+    scmid: default
+
+actions:
+  default:
+    kind: github/pullrequest
+    title: Bump `nodejs` version to {{ source "packerImageNodeVersion" }}
+    scmid: default
+    spec:
+      labels:
+        - dependencies
+        - nodejs

--- a/updatecli/values.yaml
+++ b/updatecli/values.yaml
@@ -1,0 +1,8 @@
+github:
+  user: "Jenkins Infra Bot (updatecli)"
+  email: "60776566+jenkins-infra-bot@users.noreply.github.com"
+  username: "jenkins-infra-bot"
+  token: "UPDATECLI_GITHUB_TOKEN"
+  branch: "main"
+  owner: "jenkins-infra"
+  repository: "contributor-spotlight"


### PR DESCRIPTION
This PR adds an updatecli manifest to retrieve `nodejs_linux_version` from https://github.com/jenkins-infra/packer-images/blob/main/provisioning/tools-versions.yml so it's the same as the one installed on agents.

Closes:
- #124

Closes https://github.com/jenkins-infra/contributor-spotlight/pull/127#issuecomment-2104479502 (to validate updatecli main build)