### PR TITLE
fix: fix images not centered in respective container issue

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -24,7 +24,11 @@ const IndexPage = (props) => {
                     key={idx}
                 >
                     <Box padding={isDesktop ? 5 : 2} key={idx}>
-                        <Box>
+                        <Box
+                            display='flex'
+                            justifyContent='center'
+                            alignItems='center'
+                        >
                             <img
                                 src={contributor.node.pageAttributes.image}
                                 alt='Contributor avatar'


### PR DESCRIPTION
To make sure that the images are positioned horizontally in the center of their respective containers, as shown in screenshot below:

<img width="1435" alt="Screenshot 2024-06-29 at 8 55 27 PM" src="https://github.com/jenkins-infra/contributor-spotlight/assets/88480540/c8e6a003-2976-4c9e-8c3a-f57b9f2a911a">
