### PR TITLE
Don't display "First commit" if there is none

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -287,21 +287,28 @@ const IndexPage = (props) => {
                                                         .pageAttributes.location
                                                 }
                                             </Typography>
-                                            <Typography
-                                                variant='h5'
-                                                textAlign={
-                                                    isDesktop
-                                                        ? 'left'
-                                                        : 'center'
-                                                }
-                                            >
-                                                First Commit:{' '}
-                                                {
-                                                    contributor.node
-                                                        .pageAttributes
-                                                        .firstcommit
-                                                }
-                                            </Typography>
+                                            {contributor.node.pageAttributes
+                                                .firstcommit &&
+                                                contributor.node.pageAttributes
+                                                    .firstcommit !== 'null' &&
+                                                contributor.node.pageAttributes
+                                                    .firstcommit !== '' && (
+                                                    <Typography
+                                                        variant='h5'
+                                                        textAlign={
+                                                            isDesktop
+                                                                ? 'left'
+                                                                : 'center'
+                                                        }
+                                                    >
+                                                        First Commit:{' '}
+                                                        {
+                                                            contributor.node
+                                                                .pageAttributes
+                                                                .firstcommit
+                                                        }
+                                                    </Typography>
+                                                )}
                                         </Box>
 
                                         <Box

--- a/src/templates/contributor-details.jsx
+++ b/src/templates/contributor-details.jsx
@@ -128,11 +128,11 @@ function ContributorDetails(props) {
                             {props.data.asciidoc.pageAttributes.location ??
                                 'World'}
                         </Typography>
-                        <Typography variant='h6' textAlign='center'>
-                            {'First Commit: ' +
-                                props.data.asciidoc.pageAttributes
-                                    .firstcommit ?? 'Unknown'}
-                        </Typography>
+                        {props.data.asciidoc.pageAttributes.firstcommit && props.data.asciidoc.pageAttributes.firstcommit !== 'null' && props.data.asciidoc.pageAttributes.firstcommit !== '' && (
+                            <Typography variant='h6' textAlign='center'>
+                                {'First Commit: ' + props.data.asciidoc.pageAttributes.firstcommit}
+                            </Typography>
+                        )}
                     </Box>
                     <Box sx={{ paddingBottom: 1.5 }}>
                         <Typography variant='h6' textAlign='center'>


### PR DESCRIPTION
- Fix #354 