### PR TITLE
Fix production console errors on index page

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import '../../styles/index.css';
 import { Box, Stack, Typography, useTheme } from '@mui/material';
 import { graphql } from 'gatsby';
@@ -57,9 +57,20 @@ const IndexPage = (props) => {
 
         return () => clearInterval(interval);
     }, []);
+
+    const [mounted, setMounted] = useState(false);
+
+    useEffect(() => {
+        setMounted(true);
+    }, []);
+
     const featuredContributor = contributors.find(
         (contributor) => contributor.node.pageAttributes.featured === 'true'
     );
+    if (!mounted) {
+        return null;
+    }
+
     return (
         <>
             <Helmet>


### PR DESCRIPTION

<img width="1625" height="954" alt="image" src="https://github.com/user-attachments/assets/ca03d4f0-b2cf-4221-9b1e-f5fefaeb67f5" />



The home page was crashing in production builds with React hydration errors (418 / 423).

This happened because the page relies on browser-only information, such as screen size (useMediaQuery) and system color scheme (matchMedia), during the initial render. During SSR, Gatsby cannot know these values, which caused the server-rendered HTML to differ from what React rendered in the browser.

The fix avoids evaluating browser-only values during SSR by ensuring rendering happens only once those values are available on the client. This keeps the server and client output consistent and prevents hydration errors in production.