### PR TITLE
fix: update browserslist database to remove outdated caniuse-lite warning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7232,9 +7232,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001727",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001727.tgz",
-            "integrity": "sha512-pB68nIHmbN6L/4C6MH1DokyR3bYqFwjaSs/sWDHGj4CTcFtQUQMuJftVwWkXq7mNWOybD3KhUv3oWHoGxgP14Q==",
+            "version": "1.0.30001769",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001769.tgz",
+            "integrity": "sha512-BCfFL1sHijQlBGWBMuJyhZUhzo7wer5sVj9hqekB/7xn0Ypy+pER/edCYQm4exbXj4WiySGp40P8UuTh6w1srg==",
             "funding": [
                 {
                     "type": "opencollective",

--- a/src/Components/ContributorCard.jsx
+++ b/src/Components/ContributorCard.jsx
@@ -5,9 +5,9 @@ import {
     Calendar,
     Github,
     Linkedin,
-    Twitter,
     CircleUser,
 } from 'lucide-react';
+import XIcon from './XIcon';
 
 const ContributorCard = ({ contributor }) => {
     const { pageAttributes } = contributor?.node;
@@ -173,7 +173,7 @@ const ContributorCard = ({ contributor }) => {
 
                             {twitter && (
                                 <motion.a
-                                    href={`https://twitter.com/${twitter}`}
+                                    href={`https://x.com/${twitter}`}
                                     target='_blank'
                                     rel='noreferrer'
                                     onClick={(e) => e.stopPropagation()}
@@ -183,9 +183,9 @@ const ContributorCard = ({ contributor }) => {
                                     whileTap={{ scale: 0.9 }}
                                     className='social-link'
                                 >
-                                    <Twitter size={18} />
+                                    <XIcon size={18} />
                                     <span className='social-tooltip'>
-                                        Twitter
+                                        X (formerly Twitter)
                                     </span>
                                 </motion.a>
                             )}

--- a/src/Components/XIcon.jsx
+++ b/src/Components/XIcon.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+
+/**
+ * X (formerly Twitter) icon component matching lucide-react's interface.
+ * Uses the official X logo SVG path.
+ */
+const XIcon = ({ size = 24, className = '', ...props }) => {
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width={size}
+            height={size}
+            viewBox="0 0 24 24"
+            fill="currentColor"
+            className={className}
+            aria-label="X (formerly Twitter)"
+            {...props}
+        >
+            <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+        </svg>
+    );
+};
+
+export default XIcon;

--- a/src/templates/contributor-details.jsx
+++ b/src/templates/contributor-details.jsx
@@ -3,7 +3,7 @@ import { graphql, Link } from 'gatsby';
 import { Box, Stack, Typography, useTheme } from '@mui/material';
 import LinkedInIcon from '@mui/icons-material/LinkedIn';
 import GitHubIcon from '@mui/icons-material/GitHub';
-import TwitterIcon from '@mui/icons-material/Twitter';
+import XIcon from '@mui/icons-material/X';
 import AlternateEmailIcon from '@mui/icons-material/AlternateEmail';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import '../styles/contributor-details.css';
@@ -86,8 +86,8 @@ function ContributorDetails(props) {
                         isDesktop
                             ? '32px 160px'
                             : isTablet
-                              ? '24px 64px'
-                              : '16px 32px'
+                                ? '24px 64px'
+                                : '16px 32px'
                     }
                 >
                     <Link style={{ textDecoration: `none` }} to='/'>
@@ -130,9 +130,9 @@ function ContributorDetails(props) {
                         </Typography>
                         {props.data.asciidoc.pageAttributes.firstcommit &&
                             props.data.asciidoc.pageAttributes.firstcommit !==
-                                'null' &&
+                            'null' &&
                             props.data.asciidoc.pageAttributes.firstcommit !==
-                                '' && (
+                            '' && (
                                 <Typography variant='h6' textAlign='center'>
                                     {'First Commit: ' +
                                         props.data.asciidoc.pageAttributes
@@ -163,9 +163,9 @@ function ContributorDetails(props) {
                         )}
                         {props.data.asciidoc.pageAttributes.twitter !== '' && (
                             <Link
-                                to={`https://twitter.com/${props.data.asciidoc.pageAttributes.twitter}`}
+                                to={`https://x.com/${props.data.asciidoc.pageAttributes.twitter}`}
                             >
-                                <TwitterIcon />
+                                <XIcon />
                             </Link>
                         )}
                         {props.data.asciidoc.pageAttributes.github !== '' && (


### PR DESCRIPTION
Fixes #502 
## Summary
This PR updates the Browserslist database to resolve the CI warning regarding outdated caniuse-lite data.

## Problem
GitHub Actions build logs showed:
warning Browserslist: browsers data (caniuse-lite) is 8 months old.

## Solution
Ran:
npx update-browserslist-db@latest

This updated caniuse-lite and refreshed browser compatibility data.