### PR TITLE
fix: platform-aware keyboard shortcut hint in search bar

### DIFF
--- a/src/Components/Search/Search.jsx
+++ b/src/Components/Search/Search.jsx
@@ -9,16 +9,13 @@ function Search({ contributors, darkmode }) {
     const [isFocused, setIsFocused] = useState(false);
     const [results, setResults] = useState([]);
     const searchInputRef = useRef(null);
-    const searchPlaceholder = useMemo(() => {
-        if (typeof navigator === 'undefined')
-            return '[Ctrl + K] Search contributors...';
-        const ua = navigator.userAgent || '';
-        if (/Android|iPhone|iPad|iPod/i.test(ua))
-            return 'Search contributors...';
-        if (/Mac/i.test(navigator.platform || ''))
-            return '[⌘ + K] Search contributors...';
-        return '[Ctrl + K] Search contributors...';
-    }, []);
+    const platform = navigator.platform.toUpperCase();
+    const useCmdKey =
+        platform.indexOf('MAC') >= 0 ||
+        platform === 'IPHONE' ||
+        platform === 'IPAD';
+
+    const shortcutHint = useCmdKey ? '⌘ + K' : 'Ctrl + K';
     const contributorsArray = useMemo(() => {
         return Object.values(contributors).map((c) => ({
             id: c?.node?.id,
@@ -84,7 +81,7 @@ function Search({ contributors, darkmode }) {
                         onChange={(e) => setSearchQuery(e.target.value)}
                         onFocus={() => setIsFocused(true)}
                         onBlur={() => setIsFocused(false)}
-                        placeholder={searchPlaceholder}
+                        placeholder={`[${shortcutHint}] Search contributors...`}
                         className='search-input'
                     />
                 </motion.div>

--- a/src/Components/Search/Search.jsx
+++ b/src/Components/Search/Search.jsx
@@ -9,6 +9,16 @@ function Search({ contributors, darkmode }) {
     const [isFocused, setIsFocused] = useState(false);
     const [results, setResults] = useState([]);
     const searchInputRef = useRef(null);
+    const searchPlaceholder = useMemo(() => {
+        if (typeof navigator === 'undefined')
+            return '[Ctrl + K] Search contributors...';
+        const ua = navigator.userAgent || '';
+        if (/Android|iPhone|iPad|iPod/i.test(ua))
+            return 'Search contributors...';
+        if (/Mac/i.test(navigator.platform || ''))
+            return '[⌘ + K] Search contributors...';
+        return '[Ctrl + K] Search contributors...';
+    }, []);
     const contributorsArray = useMemo(() => {
         return Object.values(contributors).map((c) => ({
             id: c?.node?.id,
@@ -74,7 +84,7 @@ function Search({ contributors, darkmode }) {
                         onChange={(e) => setSearchQuery(e.target.value)}
                         onFocus={() => setIsFocused(true)}
                         onBlur={() => setIsFocused(false)}
-                        placeholder='[Ctrl + k] Search contributors...'
+                        placeholder={searchPlaceholder}
                         className='search-input'
                     />
                 </motion.div>


### PR DESCRIPTION
Fixes #516 
- macOS: display ⌘ + K
- Windows/Linux: display Ctrl + K
- No changes to keyboard event handling logic