### PR TITLE
fix twitter link to x.com

### DIFF
--- a/src/Components/Search/SearchResults.jsx
+++ b/src/Components/Search/SearchResults.jsx
@@ -106,7 +106,7 @@ function SearchResults({ results, darkmode }) {
                                     )}
                                     {item?.twitter && (
                                         <motion.a
-                                            href={`https://twitter.com/${item.twitter}`}
+                                            href={`https://x.com/${item.twitter}`}
                                             target='_blank'
                                             rel='noreferrer'
                                             onClick={(e) => e.stopPropagation()}


### PR DESCRIPTION
Fixes #519 

### Proposed Change

This PR updates the contributor's social Twitter link from twitter.com to x.com to ensure consistency.

BEFORE :
<img width="854" height="920" alt="Screenshot 2026-02-22 163846" src="https://github.com/user-attachments/assets/9055e48c-f475-47a6-aa53-9071b50bc5e2" />

AFTER: 
<img width="691" height="920" alt="Screenshot 2026-02-23 000241" src="https://github.com/user-attachments/assets/56a408df-6778-4a71-92e6-6cdfcd1fe7d7" />
