### PR TITLE
Searchbar mobile placeholder

### DIFF
--- a/src/Components/Search/Search.jsx
+++ b/src/Components/Search/Search.jsx
@@ -9,16 +9,13 @@ function Search({ contributors, darkmode }) {
     const [isFocused, setIsFocused] = useState(false);
     const [results, setResults] = useState([]);
     const searchInputRef = useRef(null);
-    const searchPlaceholder = useMemo(() => {
-        if (typeof navigator === 'undefined')
-            return '[Ctrl + K] Search contributors...';
-        const ua = navigator.userAgent || '';
-        if (/Android|iPhone|iPad|iPod/i.test(ua))
-            return 'Search contributors...';
-        if (/Mac/i.test(navigator.platform || ''))
-            return '[⌘ + K] Search contributors...';
-        return '[Ctrl + K] Search contributors...';
-    }, []);
+    const platform = navigator.platform.toUpperCase();
+    const useCmdKey =
+        platform.indexOf('MAC') >= 0 ||
+        platform === 'IPHONE' ||
+        platform === 'IPAD';
+
+    const shortcutHint = useCmdKey ? '⌘ + K' : 'Ctrl + K';
     const contributorsArray = useMemo(() => {
         return Object.values(contributors).map((c) => ({
             id: c?.node?.id,
@@ -84,7 +81,7 @@ function Search({ contributors, darkmode }) {
                         onChange={(e) => setSearchQuery(e.target.value)}
                         onFocus={() => setIsFocused(true)}
                         onBlur={() => setIsFocused(false)}
-                        placeholder={searchPlaceholder}
+                        placeholder={`[${shortcutHint}] Search contributors...`}
                         className='search-input'
                     />
                 </motion.div>

--- a/src/Components/Search/Search.jsx
+++ b/src/Components/Search/Search.jsx
@@ -9,6 +9,16 @@ function Search({ contributors, darkmode }) {
     const [isFocused, setIsFocused] = useState(false);
     const [results, setResults] = useState([]);
     const searchInputRef = useRef(null);
+    const searchPlaceholder = useMemo(() => {
+        if (typeof navigator === 'undefined')
+            return '[Ctrl + K] Search contributors...';
+        const ua = navigator.userAgent || '';
+        if (/Android|iPhone|iPad|iPod/i.test(ua))
+            return 'Search contributors...';
+        if (/Mac/i.test(navigator.platform || ''))
+            return '[⌘ + K] Search contributors...';
+        return '[Ctrl + K] Search contributors...';
+    }, []);
     const contributorsArray = useMemo(() => {
         return Object.values(contributors).map((c) => ({
             id: c?.node?.id,
@@ -74,7 +84,7 @@ function Search({ contributors, darkmode }) {
                         onChange={(e) => setSearchQuery(e.target.value)}
                         onFocus={() => setIsFocused(true)}
                         onBlur={() => setIsFocused(false)}
-                        placeholder='[Ctrl + k] Search contributors...'
+                        placeholder={searchPlaceholder}
                         className='search-input'
                     />
                 </motion.div>

--- a/src/Components/Search/Search.jsx
+++ b/src/Components/Search/Search.jsx
@@ -10,12 +10,16 @@ function Search({ contributors, darkmode }) {
     const [results, setResults] = useState([]);
     const searchInputRef = useRef(null);
     const platform = navigator.platform.toUpperCase();
+    const isMobile =
+        platform === 'IPHONE' ||
+        platform === 'IPAD' ||
+        /Android/i.test(navigator.userAgent);
     const useCmdKey =
         platform.indexOf('MAC') >= 0 ||
         platform === 'IPHONE' ||
         platform === 'IPAD';
 
-    const shortcutHint = useCmdKey ? '⌘ + K' : 'Ctrl + K';
+    const shortcutHint = isMobile ? null : useCmdKey ? '⌘ + K' : 'Ctrl + K';
     const contributorsArray = useMemo(() => {
         return Object.values(contributors).map((c) => ({
             id: c?.node?.id,
@@ -81,7 +85,11 @@ function Search({ contributors, darkmode }) {
                         onChange={(e) => setSearchQuery(e.target.value)}
                         onFocus={() => setIsFocused(true)}
                         onBlur={() => setIsFocused(false)}
-                        placeholder={`[${shortcutHint}] Search contributors...`}
+                        placeholder={
+                            shortcutHint
+                                ? `[${shortcutHint}] Search contributors...`
+                                : 'Search contributors...'
+                        }
                         className='search-input'
                     />
                 </motion.div>


### PR DESCRIPTION
Fixes #524 

as discussed between me and @krisstern on Gitter so it matches the requirement 

This PR updates the search placeholder behavior to improve UX on mobile devices.
Changes

On mobile devices:

- The shortcut hint is hidden.

Placeholder now displays:

`Search contributors...`

On desktop platforms (unchanged behavior):

- macOS → [⌘ + K] Search contributors...
- Windows/Linux → [Ctrl + K] Search contributors...