### PR TITLE
fix: prevent contributor card date from wrapping

### DIFF
--- a/src/Components/Contributor/contributors.css
+++ b/src/Components/Contributor/contributors.css
@@ -148,6 +148,7 @@
     padding: 0.4rem 0.8rem;
     background: rgba(255, 255, 255, 0.05);
     border-radius: 12px;
+    white-space: nowrap;
 }
 
 .contributor-links {


### PR DESCRIPTION
## Description
This PR fixes the issue where contributor card dates were wrapping onto two lines on large screens.

## Changes
- Added `white-space: nowrap;` to the date styling.

## Issue
Closes #526 

## Before
<img width="837" height="425" alt="Screenshot 2026-02-25 at 12 29 52 PM" src="https://github.com/user-attachments/assets/e3ca3210-2fcb-464d-9dee-8ebad9154a25" />

## After
<img width="1299" height="642" alt="Screenshot 2026-02-25 at 12 04 42 PM" src="https://github.com/user-attachments/assets/fc469f10-6911-4518-85b6-d318f67b433f" />