### PR TITLE
Show placeholder when profile image is missing or broken

### DIFF
--- a/src/Components/Contributor/ContributorCard.jsx
+++ b/src/Components/Contributor/ContributorCard.jsx
@@ -3,6 +3,7 @@ import { motion } from 'framer-motion';
 import { Link } from 'gatsby';
 import { Calendar, Github, Linkedin, CircleUser } from 'lucide-react';
 import XIcon from '../XIcon';
+import placeholderImage from '../../images/jenkins.png';
 
 const ContributorCard = ({ contributor }) => {
     const pageAttributes = contributor?.node?.pageAttributes ?? {};
@@ -59,9 +60,13 @@ const ContributorCard = ({ contributor }) => {
             <div className='contributor-card'>
                 <div className='contributor-image-wrapper'>
                     <motion.img
-                        src={image}
+                        src={image || placeholderImage}
                         alt={name}
                         loading='lazy'
+                        onError={(e) => {
+                            e.target.onerror = null;
+                            e.target.src = placeholderImage;
+                        }}
                         initial={{ scale: 0.8, opacity: 0 }}
                         animate={{ scale: 1, opacity: 1 }}
                         transition={{

--- a/src/Components/Featured-contributor/FeaturedContributor.jsx
+++ b/src/Components/Featured-contributor/FeaturedContributor.jsx
@@ -3,6 +3,7 @@ import { motion } from 'framer-motion';
 import { Calendar, GitCommitHorizontal, MapPin } from 'lucide-react';
 import './featured-contributor.css';
 import { Link } from 'gatsby';
+import placeholderImage from '../../images/jenkins.png';
 
 const FeaturedContributor = ({ contributor, darkmode }) => {
     if (!contributor) return null;
@@ -31,7 +32,14 @@ const FeaturedContributor = ({ contributor, darkmode }) => {
                         transition={{ delay: 0.2, duration: 0.4 }}
                         whileHover={{ scale: 1.02 }}
                     >
-                        <img src={image} alt={name} />
+                        <img
+                            src={image || placeholderImage}
+                            alt={name}
+                            onError={(e) => {
+                                e.target.onerror = null;
+                                e.target.src = placeholderImage;
+                            }}
+                        />
                     </motion.div>
 
                     <div className='featured-content'>

--- a/src/templates/contributor-details.jsx
+++ b/src/templates/contributor-details.jsx
@@ -9,6 +9,7 @@ import dayjs from 'dayjs';
 import { Github, Linkedin, Mail } from 'lucide-react';
 import XIcon from '../Components/XIcon.jsx';
 import { motion } from 'framer-motion';
+import placeholderImage from '../images/jenkins.png';
 import './contributor-details.css';
 function ContributorDetails(props) {
     const theme = useTheme();
@@ -20,7 +21,9 @@ function ContributorDetails(props) {
         ' - Jenkins Contributor Spotlight';
 
     // State for sanitized HTML
-    const [sanitizedHTML, setSanitizedHTML] = useState(props.data.asciidoc.html);
+    const [sanitizedHTML, setSanitizedHTML] = useState(
+        props.data.asciidoc.html
+    );
 
     // Sanitize HTML on client side only
     useEffect(() => {
@@ -101,13 +104,19 @@ function ContributorDetails(props) {
                     <Box sx={{ paddingTop: isMobile ? 5 : 8 }}>
                         <img
                             src={
-                                '../../../' +
                                 props.data.asciidoc.pageAttributes.image
+                                    ? '../../../' +
+                                      props.data.asciidoc.pageAttributes.image
+                                    : placeholderImage
                             }
                             alt='Contributor avatar'
                             width={isDesktop ? 350 : isTablet ? 300 : 250}
                             height={isDesktop ? 350 : isTablet ? 300 : 250}
                             style={{ objectFit: 'cover', borderRadius: '50%' }}
+                            onError={(e) => {
+                                e.target.onerror = null;
+                                e.target.src = placeholderImage;
+                            }}
                         />
                     </Box>
                 </Box>


### PR DESCRIPTION
Right now if a contributor's image is missing or the URL is broken, the card just shows the alt text which looks bad. 

This adds a fallback to [jenkins.png](cci:7://file:///c:/Users/raj97/.gemini/antigravity/scratch/contributor-spotlight/src/images/jenkins.png:0:0-0:0) (already in the repo) using `onError` on the img tags. Changed it in ContributorCard, FeaturedContributor, and the details page template.

Closes #500
