### PR TITLE
Inconsistent `useState` Usage in `index.js`

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -16,8 +16,8 @@ const IndexPage = (props) => {
     const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
     const { data } = props;
     const contributors = data.allAsciidoc.edges;
-    const [thankYou, setThankYou] = React.useState([]);
-    const [darkmode, setDarkmode] = React.useState(null);
+    const [thankYou, setThankYou] = useState([]);
+    const [darkmode, setDarkmode] = useState(null);
 
     useEffect(() => {
         if (typeof window !== 'undefined') {

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -15,7 +15,6 @@ const IndexPage = (props) => {
     const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
     const { data } = props;
     const contributors = data.allAsciidoc.edges;
-    const [thankYou, setThankYou] = useState([]);
     const [darkmode, setDarkmode] = useState(null);
 
     useEffect(() => {


### PR DESCRIPTION
In index.js, there's an inconsistency in how the useState hook is used:

Line 1: useState is imported as a named import from 'react'
Lines 19-20: The code uses `React.useState()` instead of the imported `useState()`
This creates unnecessary inconsistency. Since `useState` is already imported, it should be used directly rather than accessing it through the React namespace.