### PR TITLE
Fix inconsistent hook import order and SSR crash from navigator access in Search componentfix a bug

### DIFF
--- a/src/Components/Search/Search.jsx
+++ b/src/Components/Search/Search.jsx
@@ -8,18 +8,24 @@ function Search({ contributors, darkmode }) {
     const [searchQuery, setSearchQuery] = useState('');
     const [isFocused, setIsFocused] = useState(false);
     const [results, setResults] = useState([]);
+    const [shortcutHint, setShortcutHint] = useState(null);
     const searchInputRef = useRef(null);
-    const platform = navigator.platform.toUpperCase();
-    const isMobile =
-        platform === 'IPHONE' ||
-        platform === 'IPAD' ||
-        /Android/i.test(navigator.userAgent);
-    const useCmdKey =
-        platform.indexOf('MAC') >= 0 ||
-        platform === 'IPHONE' ||
-        platform === 'IPAD';
 
-    const shortcutHint = isMobile ? null : useCmdKey ? '⌘ + K' : 'Ctrl + K';
+    useEffect(() => {
+        if (typeof window !== 'undefined') {
+            const platform = navigator.platform.toUpperCase();
+            const isMobile =
+                platform === 'IPHONE' ||
+                platform === 'IPAD' ||
+                /Android/i.test(navigator.userAgent);
+            const useCmdKey =
+                platform.indexOf('MAC') >= 0 ||
+                platform === 'IPHONE' ||
+                platform === 'IPAD';
+
+            setShortcutHint(isMobile ? null : useCmdKey ? '⌘ + K' : 'Ctrl + K');
+        }
+    }, []);
     const contributorsArray = useMemo(() => {
         return Object.values(contributors).map((c) => ({
             id: c?.node?.id,

--- a/src/templates/contributor-details.jsx
+++ b/src/templates/contributor-details.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { graphql, Link } from 'gatsby';
 import { Box, Stack, Typography, useTheme } from '@mui/material';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';


### PR DESCRIPTION
### Description

<!-- Brief description of the changes introduced in this PR. -->
Fix inconsistent hook import order and SSR crash from navigator access in Search component

Description:

Here I found two issues: first, inconsistent React hook import order where `contributor-details.jsx` imported `useState`, `useEffect` while all other files used `useEffect`, `useState`; second, a Server-Side Rendering (SSR) crash in `Search.jsx` caused by accessing the browser's navigator object directly during component initialization, which doesn't exist on the server during Gatsby's build process. I fixed the import order for consistency and wrapped the navigator access inside a `useEffect` hook with an SSR safety check (`typeof window !== 'undefined'`), converting `shortcutHint` to state so it initializes as null on the server and updates only after the component mounts in the browser, preventing the build crash while maintaining functionality.

### Fixes

<!-- Fixes #issue_number -->

### Screenshots (if applicable)

<!-- Add screenshots or recordings if this PR includes UI changes -->

### Checklist

- [x] PR title is clear and descriptive
- [x] Changes follow project conventions
- [x] No unrelated changes included
- [ ] Documentation updated if needed

### Additional Context

<!-- Any extra information reviewers should know -->
