### PR TITLE
Fixed location typo in Allan Burdajewicz's contributor card

### DIFF
--- a/src/pages/contributors/allan-burdajewicz.adoc
+++ b/src/pages/contributors/allan-burdajewicz.adoc
@@ -6,7 +6,7 @@
 :page-email:
 :page-image: avatar/allan-burdajewicz.png
 :page-pronouns: 
-:page-location: Queesland, Australia
+:page-location: Queensland, Australia
 :page-firstcommit: 2013
 :page-datepublished: 2025-08-28
 :page-featured: true


### PR DESCRIPTION
### Description

- Changed `:page-location: Queesland, Australia` to `Queensland: Australia`

### Fixes

Fixes Issue #543 

### Screenshots (if applicable)

<img width="925" height="766" alt="image" src="https://github.com/user-attachments/assets/f89ca058-3e46-40c5-a0a1-a02d76f908fd" />

### Checklist

- [x] PR title is clear and descriptive
- [x] Changes follow project conventions
- [x] No unrelated changes included
- [x] Documentation updated if needed