### PR TITLE
Added aria-hidden='true' to the <svg> in XIcon.jsx

### DIFF
--- a/src/Components/XIcon.jsx
+++ b/src/Components/XIcon.jsx
@@ -13,7 +13,7 @@ const XIcon = ({ size = 24, className = '', ...props }) => {
             viewBox='0 0 24 24'
             fill='currentColor'
             className={className}
-            aria-label='X (formerly Twitter)'
+            aria-hidden={true}
             {...props}
         >
             <path d='M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z' />


### PR DESCRIPTION
### Description

- Addd aria-hidden="true" to the <svg> in XIcon.jsx since the tooltip already provides the label.

### Fixes

Fixes #545 

### Screenshots (if applicable)

Before:
<img width="389" height="264" alt="image" src="https://github.com/user-attachments/assets/b50f083e-e313-420a-9923-598eaffee0d9" />

After:
<img width="384" height="306" alt="image" src="https://github.com/user-attachments/assets/e5e90739-85b7-4528-b4f9-9a7fcd09184a" />

(Name was originally appearing twice)