### PR TITLE
fix: remove duplicate gatsby-transformer-asciidoc plugin

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -30,7 +30,6 @@ module.exports = {
                 icon: `${__dirname}/src/images/jenkins.png`,
             },
         },
-        `gatsby-transformer-asciidoc`,
         {
             resolve: `gatsby-transformer-asciidoc`,
             options: {


### PR DESCRIPTION
### Description

gatsby-transformer-asciidoc was registered twice in gatsby-config.js — once as a bare string (with no options) and once as an object with the required imagesdir attribute. This caused the plugin to be loaded twice — first without the imagesdir configuration .

### Fixes

Fixes: #532

### Screenshots (if applicable)

<!-- Add screenshots or recordings if this PR includes UI changes -->

### Checklist

- [x] PR title is clear and descriptive
- [x] Changes follow project conventions
- [x] No unrelated changes included
- [ ] Documentation updated if needed

### Additional Context

### BEFORE : 
`info Total nodes: 171
verbose Number of node types: 8. Nodes per type: Asciidoc: 33, Directory: 10, File: 51, ImageSharp: 1, Site: 1, SiteBuildMetadata: 1, SitePage: 37, SitePlugin: 37
`

### AFTER: 
`info Total nodes: 170
verbose Number of node types: 8. Nodes per type: Asciidoc: 33, Directory: 10, File: 51, ImageSharp: 1, Site: 1, SiteBuildMetadata: 1, SitePage: 37, SitePlugin: 36
`
