### PR TITLE
style: fix icon alignment by standardizing sizes

### DIFF
--- a/src/Components/Featured-contributor/FeaturedContributor.jsx
+++ b/src/Components/Featured-contributor/FeaturedContributor.jsx
@@ -56,11 +56,11 @@ const FeaturedContributor = ({ contributor, darkmode }) => {
                             </span>
 
                             <span className='meta-item'>
-                                <Calendar size={12} />
+                                <Calendar size={16} />
                                 <strong>Date Published:</strong> {datepublished}
                             </span>
                             <span className='meta-item'>
-                                <GitCommitHorizontal size={12} />
+                                <GitCommitHorizontal size={16} />
                                 <strong>First Commit:</strong> {firstcommit}
                             </span>
                         </motion.div>


### PR DESCRIPTION
### Description

<!-- Brief description of the changes introduced in this PR. -->

### Fixes
Standardized the icon sizes in the FeaturedContributor component. Previously, the MapPin icon was set to 16px while others were 12px, causing the metadata text (Location, Date, Commit) to be horizontally misaligned. Set all icons to a consistent 16px for better maintainability.

<!-- Fixes #issue_number -->
Fixes #551
### Screenshots (if applicable)

<!-- Add screenshots or recordings if this PR includes UI changes -->
Before:
<img width="879" height="510" alt="Screenshot 2026-03-13 104050" src="https://github.com/user-attachments/assets/3f8d7873-9706-4ff0-85ca-582f47219907" />

After:
<img width="1837" height="982" alt="image" src="https://github.com/user-attachments/assets/0024322d-69e9-47fc-9c40-7ed51ec3cfea" />


### Checklist

- [x] PR title is clear and descriptive
- [X] Changes follow project conventions
- [X] No unrelated changes included
- [X] Documentation updated if needed

### Additional Context

<!-- Any extra information reviewers should know -->
