### PR TITLE
Fixed unique key prop bug, extracted thank you note fetching into one function

### DIFF
--- a/src/Components/ThankYouNote.jsx
+++ b/src/Components/ThankYouNote.jsx
@@ -12,16 +12,7 @@ const ThankYouNote = ({ darkmode }) => {
     const [thankYou, setThankYou] = useState([]);
 
     useEffect(() => {
-        axios
-            .get(
-                'https://raw.githubusercontent.com/jenkins-infra/jenkins-contribution-stats/main/data/honored_contributor.csv',
-                { responseType: 'text' }
-            )
-            .then((response) => {
-                setThankYou(Papa.parse(response.data)?.data[1]);
-            });
-
-        const interval = setInterval(() => {
+        const fetchHonoredContributor = () => {
             axios
                 .get(
                     'https://raw.githubusercontent.com/jenkins-infra/jenkins-contribution-stats/main/data/honored_contributor.csv',
@@ -29,8 +20,14 @@ const ThankYouNote = ({ darkmode }) => {
                 )
                 .then((response) => {
                     setThankYou(Papa.parse(response.data)?.data[1]);
+                })
+                .catch((error) => {
+                    console.error('Error fetching thank you note:', error);
                 });
-        }, 3600000);
+        };
+
+        fetchHonoredContributor();
+        const interval = setInterval(fetchHonoredContributor, 3600000);
 
         return () => clearInterval(interval);
     }, []);
@@ -123,7 +120,7 @@ const ThankYouNote = ({ darkmode }) => {
                                 .split(/\s+/)
                                 .filter(Boolean)
                                 .map((repo, idx) => (
-                                    <>
+                                    <div key={idx}>
                                         {thankYou[8]?.split(' ').length > 2 &&
                                             idx ===
                                                 thankYou[8]?.split(' ').length -
@@ -147,7 +144,7 @@ const ThankYouNote = ({ darkmode }) => {
                                         ) : (
                                             ' '
                                         )}
-                                    </>
+                                    </div>
                                 ))}{' '}
                         {thankYou[8]?.split(' ').length > 2
                             ? 'repos'

--- a/src/Components/ThankYouNote.jsx
+++ b/src/Components/ThankYouNote.jsx
@@ -120,7 +120,7 @@ const ThankYouNote = ({ darkmode }) => {
                                 .split(/\s+/)
                                 .filter(Boolean)
                                 .map((repo, idx) => (
-                                    <div key={idx}>
+                                    <React.Fragment key={idx}>
                                         {thankYou[8]?.split(' ').length > 2 &&
                                             idx ===
                                                 thankYou[8]?.split(' ').length -
@@ -144,7 +144,7 @@ const ThankYouNote = ({ darkmode }) => {
                                         ) : (
                                             ' '
                                         )}
-                                    </div>
+                                    </React.Fragment>
                                 ))}{' '}
                         {thankYou[8]?.split(' ').length > 2
                             ? 'repos'


### PR DESCRIPTION

### Description

Previously, there was a missing key prop in the list (ThankYouNote.jsx) that rendered a fragment without a key prop. This would cause a console error which could be messy during development.

There was also duplicated fetch logic when retrieving the thank you note. Extracting the fetch into a named function, calling it right away and then setting the interval afterwards can eliminate the duplication.  

### Fixes

Fixes #553 

1. Refactored empty fragment to `React.Fragment` which takes a mandatory key prop (used the index which usually isn't the most ideal, an id/uuid is - if there's something better I could've used let me know ^_^)
2. Extracted fetch logic into named const `fetchHonoredContributor` in the effect hook, gets invoked immediately and gets set into an interval with same time
3. Also, added a catch-block for fetching the thank you note to handle errors.

### Screenshots (if applicable)

No UI changes result as a part of these changes, so no screenshots are applicable.