### PR TITLE
Fix: Fix the FeaturedContributor description view by adding 'See More' toggle button.

### DIFF
--- a/src/Components/Featured-contributor/FeaturedContributor.jsx
+++ b/src/Components/Featured-contributor/FeaturedContributor.jsx
@@ -1,10 +1,17 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { motion } from 'framer-motion';
-import { Calendar, GitCommitHorizontal, MapPin } from 'lucide-react';
+import {
+    Calendar,
+    GitCommitHorizontal,
+    MapPin,
+    ChevronDown,
+} from 'lucide-react';
 import './featured-contributor.css';
 import { Link } from 'gatsby';
 
 const FeaturedContributor = ({ contributor, darkmode }) => {
+    const [isExpanded, setIsExpanded] = useState(false);
+
     if (!contributor) return null;
 
     const pageAttributes = contributor?.node?.pageAttributes;
@@ -66,7 +73,7 @@ const FeaturedContributor = ({ contributor, darkmode }) => {
                         </motion.div>
 
                         <motion.div
-                            className='featured-highlight'
+                            className={`featured-highlight ${isExpanded ? 'expanded' : ''}`}
                             initial={{ opacity: 0, y: 10 }}
                             animate={{ opacity: 1, y: 0 }}
                             transition={{ delay: 0.5 }}
@@ -75,9 +82,24 @@ const FeaturedContributor = ({ contributor, darkmode }) => {
                                 transition: { type: 'spring', stiffness: 300 },
                             }}
                         >
-                            <p className='featured-intro'>
-                                <strong>{name}</strong> {intro}
-                            </p>
+                            <div className='intro-content-wrapper'>
+                                <p className='featured-intro'>
+                                    <strong>{name}</strong> {intro}
+                                </p>
+                            </div>
+                            <button
+                                className='expand-button'
+                                onClick={(e) => {
+                                    e.preventDefault();
+                                    e.stopPropagation();
+                                    setIsExpanded(!isExpanded);
+                                }}
+                            >
+                                <ChevronDown
+                                    size={24}
+                                    className={isExpanded ? 'rotated' : ''}
+                                />
+                            </button>
                         </motion.div>
                     </div>
                 </Link>

--- a/src/Components/Featured-contributor/featured-contributor.css
+++ b/src/Components/Featured-contributor/featured-contributor.css
@@ -166,3 +166,46 @@
         font-size: 1rem;
     }
 }
+
+@media (min-width: 1025px) {
+    .expand-button {
+        display: none;
+    }
+}
+
+@media (max-width: 1024px) {
+    .intro-content-wrapper {
+        max-height: 120px;
+        overflow-y: hidden;
+        transition: max-height 0.3s ease;
+    }
+
+    .featured-highlight.expanded .intro-content-wrapper {
+        max-height: 1500px;
+    }
+
+    .expand-button {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        width: 100%;
+        background: transparent;
+        border: none;
+        color: #fca700;
+        margin-top: 5px;
+        cursor: pointer;
+        padding: 5px 0;
+    }
+
+    .featured-contributor-section.light .expand-button {
+        color: #29b4eb;
+    }
+
+    .expand-button svg {
+        transition: transform 0.3s ease;
+    }
+
+    .expand-button svg.rotated {
+        transform: rotate(180deg);
+    }
+}

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -103,7 +103,7 @@ const IndexPage = (props) => {
                 display='flex'
                 flexDirection='column'
                 alignItems='center'
-                justifyContent='flex-start'
+                justifyContent='center'
                 padding={isMobile ? 5 : 10}
                 sx={{
                     backgroundImage:
@@ -111,6 +111,7 @@ const IndexPage = (props) => {
                     backgroundRepeat: 'no-repeat',
                     backgroundSize: 'cover',
                     backgroundPosition: 'center',
+                    height: '65dvh',
                 }}
             >
                 <Typography
@@ -123,8 +124,23 @@ const IndexPage = (props) => {
                     as we showcase the top contributors shaping the future of
                     continuous integration and delivery
                 </Typography>
-                <Box sx={{ paddingTop: 8 }}>
-                    <img src='/jenkins.png' alt='Jenkins logo' />
+                <Box
+                    sx={{
+                        paddingTop: 8,
+                    }}
+                >
+                    <img
+                        style={{
+                            width: '150px',
+                            objectFit: 'cover',
+                            borderRadius: '50%',
+                            display: 'relative',
+                            justifyContent: 'center',
+                            alignItems: 'center',
+                        }}
+                        src='/jenkins.png'
+                        alt='Jenkins logo'
+                    />
                 </Box>
             </Box>
 

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -77,7 +77,7 @@ const IndexPage = (props) => {
                 display='flex'
                 flexDirection='column'
                 alignItems='center'
-                justifyContent='center'
+                justifyContent='flex-start'
                 padding={isMobile ? 5 : 10}
                 sx={{
                     backgroundImage:
@@ -85,7 +85,6 @@ const IndexPage = (props) => {
                     backgroundRepeat: 'no-repeat',
                     backgroundSize: 'cover',
                     backgroundPosition: 'center',
-                    height: '65dvh',
                 }}
             >
                 <Typography
@@ -98,23 +97,8 @@ const IndexPage = (props) => {
                     as we showcase the top contributors shaping the future of
                     continuous integration and delivery
                 </Typography>
-                <Box
-                    sx={{
-                        paddingTop: 8,
-                    }}
-                >
-                    <img
-                        style={{
-                            width: '150px',
-                            objectFit: 'cover',
-                            borderRadius: '50%',
-                            display: 'relative',
-                            justifyContent: 'center',
-                            alignItems: 'center',
-                        }}
-                        src='/jenkins.png'
-                        alt='Jenkins logo'
-                    />
+                <Box sx={{ paddingTop: 8 }}>
+                    <img src='/jenkins.png' alt='Jenkins logo' />
                 </Box>
             </Box>
 


### PR DESCRIPTION
* **Fix :** Improves UX by managing the length of the first committer's description box across different screen sizes.

---

**Key Changes:**

**1. File:** `src/Components/Featured-contributor/FeaturedContributor.jsx`
* Added a `useState` variable to toggle between closed and expanded views.
* Wrapped the description paragraph inside an additional `div` tag.
* Added a toggle button immediately after the new `div` to switch the state between true and false.

  **Why:**
  * The state variable tracks the button click, adding an `"expanded"` class to the parent `div` when active.
  * Wrapping the paragraph prevents the toggle button from accidentally being hidden.
  * The button changes the state while preventing default anchor tag execution and stopping event propagation (so clicking it doesn't trigger the parent `motion.div` animations).

**2. File:** `src/Components/Featured-contributor/featured-contributor.css`
* Ensured these layout changes only apply to screen sizes smaller than a desktop.
* Added styling to the `"expanded"` class to ensure a gradual, smooth transition between toggles.



**Visual Proof**:
Before:

<img width="300" alt="Screenshot 2026-03-13 022814" src="https://github.com/user-attachments/assets/db58254b-7dff-46cb-b82b-a164aefb0ce1" />
<img width="200" alt="Screenshot 2026-03-13 022736" src="https://github.com/user-attachments/assets/2fcd81a3-e0b8-499c-8a76-c3b6b3c087f8" />
<img width="200" alt="Screenshot 2026-03-13 022704" src="https://github.com/user-attachments/assets/3b417ad4-9ffa-4e8b-8ec6-ec3a2a81a22c" />

After:

<img width="300" alt="Screenshot 2026-03-13 211137" src="https://github.com/user-attachments/assets/62b768b3-73d3-4524-840a-aa2e3c495b4c" />
<img width="200" alt="Screenshot 2026-03-13 211110" src="https://github.com/user-attachments/assets/99177771-b454-494f-be55-9de72c90aa2e" />
<img width="200" alt="Screenshot 2026-03-13 211044" src="https://github.com/user-attachments/assets/fef0f9eb-d32d-4560-a72a-c9a7ed933476" />

