### PR TITLE
Reversed breakpoint range, refactored fontweight to fontWeight

### DIFF
--- a/src/templates/contributor-details.jsx
+++ b/src/templates/contributor-details.jsx
@@ -13,7 +13,7 @@ import './contributor-details.css';
 function ContributorDetails(props) {
     const theme = useTheme();
     const isDesktop = useMediaQuery(theme.breakpoints.up('lg'));
-    const isTablet = useMediaQuery(theme.breakpoints.between('lg', 'sm'));
+    const isTablet = useMediaQuery(theme.breakpoints.between('sm', 'lg'));
     const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
     const darkmode = useMediaQuery('(prefers-color-scheme: dark)');
     const title =
@@ -133,7 +133,7 @@ function ContributorDetails(props) {
                     <Box sx={{ paddingBottom: 2, paddingTop: 2 }}>
                         <Typography
                             variant='h5'
-                            fontweight={500}
+                            fontWeight={500}
                             textAlign='center'
                         >
                             Contributor Spotlight


### PR DESCRIPTION
### Description

- Reversed `isTablet` range from 'lg', 'sm' to 'sm', 'lg
- Fixed typo from fontweight to fontWeight

### Fixes

Fixes #556 

### Screenshots (if applicable)

<img width="950" height="351" alt="image" src="https://github.com/user-attachments/assets/be3c9f54-c78e-4c33-ab20-260b80400cf3" />

(font-weight: 500 now applied)

Tested on tablet-width size:

<img width="948" height="419" alt="image" src="https://github.com/user-attachments/assets/c87e7a11-b974-4032-b085-43c56f5213a0" />

(Now 300x300 instead of 250x250)