### PR TITLE
Fix nested anchor tag issue in ContributorCard component

### DIFF
--- a/src/Components/Contributor/ContributorCard.jsx
+++ b/src/Components/Contributor/ContributorCard.jsx
@@ -68,15 +68,15 @@ const ContributorCard = ({ contributor }) => {
     };
 
     return (
-        <Link
-            to={slug}
-            style={{
-                textDecoration: 'none',
-                color: 'inherit',
-                display: 'block',
-            }}
-        >
-            <div className='contributor-card'>
+        <div className='contributor-card'>
+            <Link
+                to={slug}
+                style={{
+                    textDecoration: 'none',
+                    color: 'inherit',
+                    display: 'block',
+                }}
+            >
                 <div className='contributor-image-wrapper'>
                     <motion.img
                         src={image}
@@ -155,77 +155,72 @@ const ContributorCard = ({ contributor }) => {
                         </motion.div>
                     )}
                 </div>
+            </Link>
+            <motion.div
+                className='contributor-links'
+                initial='hidden'
+                animate='visible'
+            >
+                {github || linkedin || twitter ? (
+                    <>
+                        {github && (
+                            <motion.a
+                                href={`https://github.com/${github}`}
+                                target='_blank'
+                                rel='noreferrer'
+                                onClick={(e) => e.stopPropagation()}
+                                variants={socialLinkVariants}
+                                custom={0}
+                                whileHover='hover'
+                                whileTap={{ scale: 0.9 }}
+                                className='social-link'
+                            >
+                                <Github size={18} />
+                                <span className='social-tooltip'>GitHub</span>
+                            </motion.a>
+                        )}
 
-                <motion.div
-                    className='contributor-links'
-                    initial='hidden'
-                    animate='visible'
-                >
-                    {github || linkedin || twitter ? (
-                        <>
-                            {github && (
-                                <motion.a
-                                    href={`https://github.com/${github}`}
-                                    target='_blank'
-                                    rel='noreferrer'
-                                    onClick={(e) => e.stopPropagation()}
-                                    variants={socialLinkVariants}
-                                    custom={0}
-                                    whileHover='hover'
-                                    whileTap={{ scale: 0.9 }}
-                                    className='social-link'
-                                >
-                                    <Github size={18} />
-                                    <span className='social-tooltip'>
-                                        GitHub
-                                    </span>
-                                </motion.a>
-                            )}
+                        {linkedin && (
+                            <motion.a
+                                href={`https://linkedin.com/in/${linkedin}`}
+                                target='_blank'
+                                rel='noreferrer'
+                                onClick={(e) => e.stopPropagation()}
+                                variants={socialLinkVariants}
+                                custom={1}
+                                whileHover='hover'
+                                whileTap={{ scale: 0.9 }}
+                                className='social-link'
+                            >
+                                <Linkedin size={18} />
+                                <span className='social-tooltip'>LinkedIn</span>
+                            </motion.a>
+                        )}
 
-                            {linkedin && (
-                                <motion.a
-                                    href={`https://linkedin.com/in/${linkedin}`}
-                                    target='_blank'
-                                    rel='noreferrer'
-                                    onClick={(e) => e.stopPropagation()}
-                                    variants={socialLinkVariants}
-                                    custom={1}
-                                    whileHover='hover'
-                                    whileTap={{ scale: 0.9 }}
-                                    className='social-link'
-                                >
-                                    <Linkedin size={18} />
-                                    <span className='social-tooltip'>
-                                        LinkedIn
-                                    </span>
-                                </motion.a>
-                            )}
-
-                            {twitter && (
-                                <motion.a
-                                    href={`https://x.com/${twitter}`}
-                                    target='_blank'
-                                    rel='noreferrer'
-                                    onClick={(e) => e.stopPropagation()}
-                                    variants={socialLinkVariants}
-                                    custom={2}
-                                    whileHover='hover'
-                                    whileTap={{ scale: 0.9 }}
-                                    className='social-link'
-                                >
-                                    <XIcon size={18} />
-                                    <span className='social-tooltip'>
-                                        X (formerly Twitter)
-                                    </span>
-                                </motion.a>
-                            )}
-                        </>
-                    ) : (
-                        <span className='no-social-data'>No social links</span>
-                    )}
-                </motion.div>
-            </div>
-        </Link>
+                        {twitter && (
+                            <motion.a
+                                href={`https://x.com/${twitter}`}
+                                target='_blank'
+                                rel='noreferrer'
+                                onClick={(e) => e.stopPropagation()}
+                                variants={socialLinkVariants}
+                                custom={2}
+                                whileHover='hover'
+                                whileTap={{ scale: 0.9 }}
+                                className='social-link'
+                            >
+                                <XIcon size={18} />
+                                <span className='social-tooltip'>
+                                    X (formerly Twitter)
+                                </span>
+                            </motion.a>
+                        )}
+                    </>
+                ) : (
+                    <span className='no-social-data'>No social links</span>
+                )}
+            </motion.div>
+        </div>
     );
 };
 


### PR DESCRIPTION
### Description

 This PR fixes an invalid HTML structure in the ContributorCard component that resulted in nested <a> elements.

Previously, the entire contributor card was wrapped with Gatsby’s <Link> component while the card also contained external links for social profiles (GitHub, LinkedIn, and X). Since Gatsby’s <Link> renders an <a> element internally, this caused <a> elements to be nested inside another <a>, which triggered the following console warning during development.

To resolve this issue, the component structure has been updated so that the <Link> only wraps the main card content that navigates to the contributor profile page, while the external social media links remain outside the <Link> element. This prevents nested anchor tags and resolves the hydration warning while preserving the intended navigation behavior.

This change improves HTML validity, removes console warnings during development, and ensures better accessibility and DOM correctness.

### Fixes

 Fixes #558 

### Additional Context

Prettier and ESLint were both run before submitting this PR to ensure the code follows the repository’s formatting and linting rules.