### PR TITLE
Fix: tablet responsive layout issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ public
 src/.DS_Store
 .eslintcache
 .nvmrc
+issues.md

--- a/src/Components/Contributor/contributors.css
+++ b/src/Components/Contributor/contributors.css
@@ -11,6 +11,18 @@
     gap: 2rem;
 }
 
+@media (min-width: 768px) and (max-width: 1200px) {
+    .contributors-grid {
+        grid-template-columns: repeat(2, minmax(280px, 1fr));
+    }
+}
+
+@media (max-width: 767px) {
+    .contributors-grid {
+        grid-template-columns: minmax(280px, 1fr);
+    }
+}
+
 .contributor-card {
     background: linear-gradient(
         145deg,

--- a/src/templates/contributor-details.jsx
+++ b/src/templates/contributor-details.jsx
@@ -13,7 +13,7 @@ import './contributor-details.css';
 function ContributorDetails(props) {
     const theme = useTheme();
     const isDesktop = useMediaQuery(theme.breakpoints.up('lg'));
-    const isTablet = useMediaQuery(theme.breakpoints.between('lg', 'sm'));
+    const isTablet = useMediaQuery(theme.breakpoints.between('sm', 'lg'));
     const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
     const darkmode = useMediaQuery('(prefers-color-scheme: dark)');
     const title =


### PR DESCRIPTION
## Summary

Fixes two tablet responsive layout issues on the contributor spotlight pages.

fixes #560 

## Previously on Ipad Air:
<img width="355" height="443" alt="Screenshot 2026-03-17 020437" src="https://github.com/user-attachments/assets/0bd85d5c-15cf-4c6b-a333-73d4e7e4ff7b" />

## After fix:
<img width="263" height="349" alt="Screenshot 2026-03-17 022327" src="https://github.com/user-attachments/assets/9e36cbae-b79e-4a2d-b02c-7322722d3081" />


## Changes

### 1. Fix `isTablet` breakpoint — reversed arguments in `contributor-details.jsx`

**File:** `src/templates/contributor-details.jsx` (line 16)

```diff
- const isTablet = useMediaQuery(theme.breakpoints.between('lg', 'sm'));
+ const isTablet = useMediaQuery(theme.breakpoints.between('sm', 'lg'));
```

MUI's `breakpoints.between(start, end)` requires the smaller breakpoint first. The previous order (`'lg'`, `'sm'`) generated:

```
@media (min-width: 1200px) and (max-width: 600px)
```

This is an impossible condition, so `isTablet` was always `false`. Tablet users (600px–1200px viewports) were permanently served the mobile layout:
- Contributor avatar rendered at `250px` instead of `300px`
- Content padding was `16px 32px` instead of `24px 64px`

### 2. Explicit tablet/mobile grid breakpoints — `contributors.css`

**File:** `src/Components/Contributor/contributors.css`

Also Added two media query overrides to ensure the contributors grid behaves consistently across device widths:

- **Tablet (768px–1200px):** Force 2-column layout — `repeat(2, minmax(280px, 1fr))`
- **Mobile (≤ 767px):** Force 1-column layout — `minmax(280px, 1fr)`

### what happened Previously?
I have found that  `auto-fit` with `minmax(320px, 380px)` caused inconsistent column counts depending on exact viewport width and container padding — confirmed on iPad Air (820px wide) dropping to 1 column while iPad Pro (1024px wide) showed 2 columns.

## Testing

Tested on:
✅ iPad Air (820×1180) — now shows 2 columns 
✅ iPad Pro (1024×1366) — shows 2 columns 
✅ Mobile (< 768px) — shows 1 column 
✅ Desktop (> 1200px) — unaffected 

## Type of change

- [x] Bug fix
