### PR TITLE
chore: separate lint check and lint fix scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,9 @@
         "info": "gatsby info",
         "clean": "gatsby clean",
         "prepare": "husky",
-        "lint": "ESLINT_USE_FLAT_CONFIG=true npx eslint --fix src/",
-        "format": "npx prettier . --write"
+        "lint": "ESLINT_USE_FLAT_CONFIG=true eslint src/",
+        "lint:fix": "ESLINT_USE_FLAT_CONFIG=true eslint --fix src/",
+        "format": "prettier . --write"
     },
     "dependencies": {
         "@emotion/react": "^11.11.1",


### PR DESCRIPTION
### Description
- Currently we have npm run lint which will modify/fix the code silently
- Another thing is that, not all the errors are fixed by  --fix. So, it's required to have some method to check where the problem has occured, So to handle that 

So, I have separated the use case here: 
- `lint` for checking
- `lint:fix` for fixing the code

### Fixes

<!-- Fixes #issue_number -->

### Screenshots (if applicable)

here `lint` shows the place where problem is occuring
but `lint:fix` which was earlier `lint` was silently fixing this issue
<img width="728" height="403" alt="image" src="https://github.com/user-attachments/assets/414daff6-9087-4979-a740-6781af41b528" />


### Checklist

- [x] PR title is clear and descriptive
- [x] Changes follow project conventions
- [x] No unrelated changes included
- [ ] Documentation updated if needed

### Additional Context

<!-- Any extra information reviewers should know -->
clean ups: 
`"format": "npx prettier . --write"` -> `"format": "prettier . --write"`