### PR TITLE
Fix nested links in search results markup

### DIFF
--- a/src/Components/Search/SearchResults.jsx
+++ b/src/Components/Search/SearchResults.jsx
@@ -46,17 +46,31 @@ function SearchResults({ results, darkmode }) {
     };
     return (
         <div className='results-container'>
-            {sortedResults.map(({ item, score }) => {
+            {sortedResults.map(({ item }) => {
                 if (!item) return null;
                 return (
-                    <Link to={item?.slug} key={item?.id}>
-                        <div className='result-card'>
+                    <div className='result-card' key={item?.id}>
+                        <Link
+                            to={item?.slug}
+                            style={{
+                                textDecoration: 'none',
+                                color: 'inherit',
+                            }}
+                        >
                             <img
                                 src={item?.image}
                                 alt={item?.name}
                                 className='result-avatar'
                             />
-                            <div className='result-content'>
+                        </Link>
+                        <div className='result-content'>
+                            <Link
+                                to={item?.slug}
+                                style={{
+                                    textDecoration: 'none',
+                                    color: 'inherit',
+                                }}
+                            >
                                 <div className='result-header'>
                                     <h3 className='result-name'>
                                         {item?.name}
@@ -66,66 +80,66 @@ function SearchResults({ results, darkmode }) {
                                 <p className='result-location'>
                                     {item?.location}
                                 </p>
+                            </Link>
 
-                                <div className='result-links'>
-                                    {item?.github && (
-                                        <motion.a
-                                            href={`https://github.com/${item.github}`}
-                                            target='_blank'
-                                            rel='noreferrer'
-                                            onClick={(e) => e.stopPropagation()}
-                                            variants={socialLinkVariants}
-                                            custom={0}
-                                            whileHover='hover'
-                                            whileTap={{ scale: 0.9 }}
-                                            className='social-link'
-                                        >
-                                            <Github size={18} />
-                                            <span className='social-tooltip'>
-                                                GitHub
-                                            </span>
-                                        </motion.a>
-                                    )}
-                                    {item?.linkedin && (
-                                        <motion.a
-                                            href={`https://linkedin.com/in/${item?.linkedin}`}
-                                            target='_blank'
-                                            rel='noreferrer'
-                                            onClick={(e) => e.stopPropagation()}
-                                            variants={socialLinkVariants}
-                                            custom={1}
-                                            whileHover='hover'
-                                            whileTap={{ scale: 0.9 }}
-                                            className='social-link'
-                                        >
-                                            <Linkedin size={18} />
-                                            <span className='social-tooltip'>
-                                                LinkedIn
-                                            </span>
-                                        </motion.a>
-                                    )}
-                                    {item?.twitter && (
-                                        <motion.a
-                                            href={`https://x.com/${item.twitter}`}
-                                            target='_blank'
-                                            rel='noreferrer'
-                                            onClick={(e) => e.stopPropagation()}
-                                            variants={socialLinkVariants}
-                                            custom={2}
-                                            whileHover='hover'
-                                            whileTap={{ scale: 0.9 }}
-                                            className='social-link'
-                                        >
-                                            <XIcon size={18} />
-                                            <span className='social-tooltip'>
-                                                X (formerly Twitter)
-                                            </span>
-                                        </motion.a>
-                                    )}
-                                </div>
+                            <div className='result-links'>
+                                {item?.github && (
+                                    <motion.a
+                                        href={`https://github.com/${item.github}`}
+                                        target='_blank'
+                                        rel='noreferrer'
+                                        onClick={(e) => e.stopPropagation()}
+                                        variants={socialLinkVariants}
+                                        custom={0}
+                                        whileHover='hover'
+                                        whileTap={{ scale: 0.9 }}
+                                        className='social-link'
+                                    >
+                                        <Github size={18} />
+                                        <span className='social-tooltip'>
+                                            GitHub
+                                        </span>
+                                    </motion.a>
+                                )}
+                                {item?.linkedin && (
+                                    <motion.a
+                                        href={`https://linkedin.com/in/${item?.linkedin}`}
+                                        target='_blank'
+                                        rel='noreferrer'
+                                        onClick={(e) => e.stopPropagation()}
+                                        variants={socialLinkVariants}
+                                        custom={1}
+                                        whileHover='hover'
+                                        whileTap={{ scale: 0.9 }}
+                                        className='social-link'
+                                    >
+                                        <Linkedin size={18} />
+                                        <span className='social-tooltip'>
+                                            LinkedIn
+                                        </span>
+                                    </motion.a>
+                                )}
+                                {item?.twitter && (
+                                    <motion.a
+                                        href={`https://x.com/${item.twitter}`}
+                                        target='_blank'
+                                        rel='noreferrer'
+                                        onClick={(e) => e.stopPropagation()}
+                                        variants={socialLinkVariants}
+                                        custom={2}
+                                        whileHover='hover'
+                                        whileTap={{ scale: 0.9 }}
+                                        className='social-link'
+                                    >
+                                        <XIcon size={18} />
+                                        <span className='social-tooltip'>
+                                            X (formerly Twitter)
+                                        </span>
+                                    </motion.a>
+                                )}
                             </div>
                         </div>
-                    </Link>
+                    </div>
                 );
             })}
         </div>


### PR DESCRIPTION
### Description

This PR fixes invalid nested link markup in search result cards by separating profile navigation Links from social anchor links.
### Fixes
#566 

### What was done:

- Updated [SearchResults.jsx]to remove the outer Link wrapping the full card.
- Kept contributor profile navigation Links around profile content only.
- Left social links as standalone external anchors (GitHub/LinkedIn/X), avoiding anchor-inside-anchor structure.
- Removed unused score argument from the map callback (sorting by score is still preserved before rendering).

### Result:

- Valid interactive structure.
- Cleaner render logic.
- No behavior change to sorting or social link actions.

### Checklist

- [x] PR title is clear and descriptive
- [x] Changes follow project conventions
- [x] No unrelated changes included
- [x] Ran both link and format checks 

