### PR TITLE
fix: remove duplicate @media query definition in featured-contributor.css

### DIFF
--- a/src/Components/Featured-contributor/featured-contributor.css
+++ b/src/Components/Featured-contributor/featured-contributor.css
@@ -76,35 +76,6 @@
     text-decoration: none !important;
 }
 
-@media (max-width: 768px) {
-    .featured-contributor-card {
-        flex-direction: column;
-        text-align: center;
-        gap: 1.5rem;
-        padding: 1.5rem;
-    }
-
-    .featured-role {
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        gap: 0.2rem;
-    }
-
-    .featured-name {
-        font-size: 1.75rem;
-    }
-
-    .featured-image img {
-        width: 150px;
-        height: 150px;
-    }
-
-    .featured-intro {
-        font-size: 1rem;
-    }
-}
-
 .featured-contributor-section.light {
     background: #ffffff;
 }


### PR DESCRIPTION
### Description

Removed duplicate @media (max-width: 768px) block from `featured-contributor.css`. The same media query rules were defined twice (lines 79-106 and lines 141-168). 

### Fixes #569 

Removed the duplicate, keeping the second occurrence at the end of the file following CSS cascade conventions.

### Screenshots (if applicable)

N/A

### Checklist

- [x] PR title is clear and descriptive
- [x] Changes follow project conventions
- [x] No unrelated changes included
- [x] Documentation updated if needed

### Additional Context

Both blocks were identical, so this is a pure de-duplication with no functional impact.
