### PR TITLE
Refactor social link rendering into shared reusable component

### DIFF
--- a/src/Components/Contributor/ContributorCard.jsx
+++ b/src/Components/Contributor/ContributorCard.jsx
@@ -1,14 +1,8 @@
 import React from 'react';
 import { motion } from 'framer-motion';
 import { Link } from 'gatsby';
-import {
-    Calendar,
-    Github,
-    Linkedin,
-    CircleUser,
-    GitCommitVertical,
-} from 'lucide-react';
-import XIcon from '../XIcon';
+import { Calendar, CircleUser, GitCommitVertical } from 'lucide-react';
+import SocialLinks from '../SocialLinks.jsx';
 
 const ContributorCard = ({ contributor }) => {
     const pageAttributes = contributor?.node?.pageAttributes ?? {};
@@ -25,24 +19,6 @@ const ContributorCard = ({ contributor }) => {
         twitter,
         pronouns,
     } = pageAttributes;
-    const socialLinkVariants = {
-        hidden: { opacity: 0, scale: 0.8 },
-        visible: (i) => ({
-            opacity: 1,
-            scale: 1,
-            transition: {
-                delay: i * 0.1,
-                type: 'spring',
-                stiffness: 200,
-                damping: 15,
-            },
-        }),
-        hover: {
-            scale: 1.2,
-            rotate: 5,
-            transition: { type: 'spring', stiffness: 400 },
-        },
-    };
     const badgeVariants = {
         hidden: { opacity: 0, scale: 0.6, y: -10 },
         visible: {
@@ -161,68 +137,13 @@ const ContributorCard = ({ contributor }) => {
                     initial='hidden'
                     animate='visible'
                 >
-                    {github || linkedin || twitter ? (
-                        <>
-                            {github && (
-                                <motion.a
-                                    href={`https://github.com/${github}`}
-                                    target='_blank'
-                                    rel='noreferrer'
-                                    onClick={(e) => e.stopPropagation()}
-                                    variants={socialLinkVariants}
-                                    custom={0}
-                                    whileHover='hover'
-                                    whileTap={{ scale: 0.9 }}
-                                    className='social-link'
-                                >
-                                    <Github size={18} />
-                                    <span className='social-tooltip'>
-                                        GitHub
-                                    </span>
-                                </motion.a>
-                            )}
-
-                            {linkedin && (
-                                <motion.a
-                                    href={`https://linkedin.com/in/${linkedin}`}
-                                    target='_blank'
-                                    rel='noreferrer'
-                                    onClick={(e) => e.stopPropagation()}
-                                    variants={socialLinkVariants}
-                                    custom={1}
-                                    whileHover='hover'
-                                    whileTap={{ scale: 0.9 }}
-                                    className='social-link'
-                                >
-                                    <Linkedin size={18} />
-                                    <span className='social-tooltip'>
-                                        LinkedIn
-                                    </span>
-                                </motion.a>
-                            )}
-
-                            {twitter && (
-                                <motion.a
-                                    href={`https://x.com/${twitter}`}
-                                    target='_blank'
-                                    rel='noreferrer'
-                                    onClick={(e) => e.stopPropagation()}
-                                    variants={socialLinkVariants}
-                                    custom={2}
-                                    whileHover='hover'
-                                    whileTap={{ scale: 0.9 }}
-                                    className='social-link'
-                                >
-                                    <XIcon size={18} />
-                                    <span className='social-tooltip'>
-                                        X (formerly Twitter)
-                                    </span>
-                                </motion.a>
-                            )}
-                        </>
-                    ) : (
-                        <span className='no-social-data'>No social links</span>
-                    )}
+                    <SocialLinks
+                        github={github}
+                        linkedin={linkedin}
+                        twitter={twitter}
+                        onLinkClick={(e) => e.stopPropagation()}
+                        showNoSocialText
+                    />
                 </motion.div>
             </div>
         </Link>

--- a/src/Components/Search/SearchResults.jsx
+++ b/src/Components/Search/SearchResults.jsx
@@ -1,9 +1,7 @@
 import React from 'react';
 import './search-result.css';
 import { Link } from 'gatsby';
-import { Github, Linkedin } from 'lucide-react';
-import { motion } from 'framer-motion';
-import XIcon from '../XIcon.jsx';
+import SocialLinks from '../SocialLinks.jsx';
 
 function SearchResults({ results, darkmode }) {
     if (!results || results.length === 0) {
@@ -26,24 +24,6 @@ function SearchResults({ results, darkmode }) {
         );
     }
     const sortedResults = [...results].sort((a, b) => a.score - b.score);
-    const socialLinkVariants = {
-        hidden: { opacity: 0, scale: 0.8 },
-        visible: (i) => ({
-            opacity: 1,
-            scale: 1,
-            transition: {
-                delay: i * 0.1,
-                type: 'spring',
-                stiffness: 200,
-                damping: 15,
-            },
-        }),
-        hover: {
-            scale: 1.2,
-            rotate: 5,
-            transition: { type: 'spring', stiffness: 400 },
-        },
-    };
     return (
         <div className='results-container'>
             {sortedResults.map(({ item, score }) => {
@@ -68,60 +48,12 @@ function SearchResults({ results, darkmode }) {
                                 </p>
 
                                 <div className='result-links'>
-                                    {item?.github && (
-                                        <motion.a
-                                            href={`https://github.com/${item.github}`}
-                                            target='_blank'
-                                            rel='noreferrer'
-                                            onClick={(e) => e.stopPropagation()}
-                                            variants={socialLinkVariants}
-                                            custom={0}
-                                            whileHover='hover'
-                                            whileTap={{ scale: 0.9 }}
-                                            className='social-link'
-                                        >
-                                            <Github size={18} />
-                                            <span className='social-tooltip'>
-                                                GitHub
-                                            </span>
-                                        </motion.a>
-                                    )}
-                                    {item?.linkedin && (
-                                        <motion.a
-                                            href={`https://linkedin.com/in/${item?.linkedin}`}
-                                            target='_blank'
-                                            rel='noreferrer'
-                                            onClick={(e) => e.stopPropagation()}
-                                            variants={socialLinkVariants}
-                                            custom={1}
-                                            whileHover='hover'
-                                            whileTap={{ scale: 0.9 }}
-                                            className='social-link'
-                                        >
-                                            <Linkedin size={18} />
-                                            <span className='social-tooltip'>
-                                                LinkedIn
-                                            </span>
-                                        </motion.a>
-                                    )}
-                                    {item?.twitter && (
-                                        <motion.a
-                                            href={`https://x.com/${item.twitter}`}
-                                            target='_blank'
-                                            rel='noreferrer'
-                                            onClick={(e) => e.stopPropagation()}
-                                            variants={socialLinkVariants}
-                                            custom={2}
-                                            whileHover='hover'
-                                            whileTap={{ scale: 0.9 }}
-                                            className='social-link'
-                                        >
-                                            <XIcon size={18} />
-                                            <span className='social-tooltip'>
-                                                X (formerly Twitter)
-                                            </span>
-                                        </motion.a>
-                                    )}
+                                    <SocialLinks
+                                        github={item?.github}
+                                        linkedin={item?.linkedin}
+                                        twitter={item?.twitter}
+                                        onLinkClick={(e) => e.stopPropagation()}
+                                    />
                                 </div>
                             </div>
                         </div>

--- a/src/Components/SocialLinks.jsx
+++ b/src/Components/SocialLinks.jsx
@@ -1,0 +1,95 @@
+import React from 'react';
+import { motion } from 'framer-motion';
+import { Github, Linkedin, Mail } from 'lucide-react';
+import XIcon from './XIcon.jsx';
+
+const socialLinkVariants = {
+    hidden: { opacity: 0, scale: 0.8 },
+    visible: (i) => ({
+        opacity: 1,
+        scale: 1,
+        transition: {
+            delay: i * 0.1,
+            type: 'spring',
+            stiffness: 200,
+            damping: 15,
+        },
+    }),
+    hover: {
+        scale: 1.2,
+        rotate: 5,
+        transition: { type: 'spring', stiffness: 400 },
+    },
+};
+
+const linkConfig = {
+    github: {
+        href: (value) => `https://github.com/${value}`,
+        label: 'GitHub',
+        icon: <Github size={18} />,
+    },
+    linkedin: {
+        href: (value) => `https://linkedin.com/in/${value}`,
+        label: 'LinkedIn',
+        icon: <Linkedin size={18} />,
+    },
+    twitter: {
+        href: (value) => `https://x.com/${value}`,
+        label: 'X (formerly Twitter)',
+        icon: <XIcon size={18} />,
+    },
+    email: {
+        href: (value) => `mailto:${value}`,
+        label: 'Email',
+        icon: <Mail size={18} />,
+    },
+};
+
+const SocialLinks = ({
+    github,
+    linkedin,
+    twitter,
+    email,
+    order = ['github', 'linkedin', 'twitter', 'email'],
+    onLinkClick,
+    showNoSocialText = false,
+}) => {
+    const values = { github, linkedin, twitter, email };
+    const links = order
+        .filter((type) => values[type])
+        .map((type, index) => ({ type, value: values[type], index }));
+
+    if (links.length === 0) {
+        return showNoSocialText ? (
+            <span className='no-social-data'>No social links</span>
+        ) : null;
+    }
+
+    return (
+        <>
+            {links.map(({ type, value, index }) => {
+                const config = linkConfig[type];
+
+                return (
+                    <motion.a
+                        key={type}
+                        href={config.href(value)}
+                        target='_blank'
+                        rel='noreferrer'
+                        onClick={onLinkClick}
+                        variants={socialLinkVariants}
+                        custom={index}
+                        whileHover='hover'
+                        whileTap={{ scale: 0.9 }}
+                        className='social-link'
+                    >
+                        {config.icon}
+                        <span className='social-tooltip'>{config.label}</span>
+                    </motion.a>
+                );
+            })}
+        </>
+    );
+};
+
+export default SocialLinks;

--- a/src/templates/contributor-details.jsx
+++ b/src/templates/contributor-details.jsx
@@ -6,9 +6,7 @@ import '../styles/contributor-details.css';
 import useMediaQuery from '@mui/material/useMediaQuery';
 import { Helmet } from 'react-helmet';
 import dayjs from 'dayjs';
-import { Github, Linkedin, Mail } from 'lucide-react';
-import XIcon from '../Components/XIcon.jsx';
-import { motion } from 'framer-motion';
+import SocialLinks from '../Components/SocialLinks.jsx';
 import './contributor-details.css';
 function ContributorDetails(props) {
     const theme = useTheme();
@@ -36,24 +34,6 @@ function ContributorDetails(props) {
         }
     }, [props.data.asciidoc.html]);
 
-    const socialLinkVariants = {
-        hidden: { opacity: 0, scale: 0.8 },
-        visible: (i) => ({
-            opacity: 1,
-            scale: 1,
-            transition: {
-                delay: i * 0.1,
-                type: 'spring',
-                stiffness: 200,
-                damping: 15,
-            },
-        }),
-        hover: {
-            scale: 1.2,
-            rotate: 5,
-            transition: { type: 'spring', stiffness: 400 },
-        },
-    };
     return (
         <>
             <Helmet>
@@ -188,72 +168,16 @@ function ContributorDetails(props) {
                         gap={1}
                         sx={{ paddingBottom: 2 }}
                     >
-                        {props.data.asciidoc.pageAttributes.linkedin !== '' && (
-                            <motion.a
-                                href={`https://linkedin.com/in/${props.data.asciidoc.pageAttributes.linkedin}`}
-                                target='_blank'
-                                rel='noreferrer'
-                                onClick={(e) => e.stopPropagation()}
-                                variants={socialLinkVariants}
-                                custom={1}
-                                whileHover='hover'
-                                whileTap={{ scale: 0.9 }}
-                                className='social-link'
-                            >
-                                <Linkedin size={18} />
-                                <span className='social-tooltip'>LinkedIn</span>
-                            </motion.a>
-                        )}
-                        {props.data.asciidoc.pageAttributes.twitter !== '' && (
-                            <motion.a
-                                href={`https://x.com/${props.data.asciidoc.pageAttributes.twitter}`}
-                                target='_blank'
-                                rel='noreferrer'
-                                onClick={(e) => e.stopPropagation()}
-                                variants={socialLinkVariants}
-                                custom={2}
-                                whileHover='hover'
-                                whileTap={{ scale: 0.9 }}
-                                className='social-link'
-                            >
-                                <XIcon size={18} />
-                                <span className='social-tooltip'>
-                                    X (formerly Twitter)
-                                </span>
-                            </motion.a>
-                        )}
-                        {props.data.asciidoc.pageAttributes.github !== '' && (
-                            <motion.a
-                                href={`https://github.com/${props.data.asciidoc.pageAttributes.github}`}
-                                target='_blank'
-                                rel='noreferrer'
-                                onClick={(e) => e.stopPropagation()}
-                                variants={socialLinkVariants}
-                                custom={0}
-                                whileHover='hover'
-                                whileTap={{ scale: 0.9 }}
-                                className='social-link'
-                            >
-                                <Github size={18} />
-                                <span className='social-tooltip'>GitHub</span>
-                            </motion.a>
-                        )}
-                        {props.data.asciidoc.pageAttributes.email !== '' && (
-                            <motion.a
-                                href={`mailto:${props.data.asciidoc.pageAttributes.email}`}
-                                target='_blank'
-                                rel='noreferrer'
-                                onClick={(e) => e.stopPropagation()}
-                                variants={socialLinkVariants}
-                                custom={1}
-                                whileHover='hover'
-                                whileTap={{ scale: 0.9 }}
-                                className='social-link'
-                            >
-                                <Mail size={18} />
-                                <span className='social-tooltip'>Email</span>
-                            </motion.a>
-                        )}
+                        <SocialLinks
+                            linkedin={
+                                props.data.asciidoc.pageAttributes.linkedin
+                            }
+                            twitter={props.data.asciidoc.pageAttributes.twitter}
+                            github={props.data.asciidoc.pageAttributes.github}
+                            email={props.data.asciidoc.pageAttributes.email}
+                            order={['linkedin', 'twitter', 'github', 'email']}
+                            onLinkClick={(e) => e.stopPropagation()}
+                        />
                     </Box>
                     <Box sx={{ my: 2 }}>
                         <Typography>


### PR DESCRIPTION
### Description

This PR removes duplicated social link rendering logic by introducing a shared SocialLinks component and replacing repeated JSX blocks in the affected views.

### Fixes #572 

### What this PR does

- Adds a shared SocialLinks component as a single source of links.
- Updates contributor card, search results, and contributor details to use the shared component.
- Preserves existing behavior and visual output

### Why this improves the codebase

- Better maintainability: future social-link changes are made once.
- Better consistency: same logic and styling path across pages.
- Better readability: parent components are shorter and easier to understand.
- Lower regression risk from duplicated UI logic.

### Checklist

- [x] PR title is clear and descriptive
- [x] Changes follow project conventions
- [x] No unrelated changes included
- [x] Confirmed behavior remains functionally the same after refactor
