### PR TITLE
Refactor: Moved repeated inline styles in contributor details to CSS classes

### DIFF
--- a/src/templates/contributor-details.css
+++ b/src/templates/contributor-details.css
@@ -50,6 +50,20 @@
     opacity: 1;
 }
 
+.contributor-details-link-plain {
+    text-decoration: none;
+}
+
+.contributor-details-link-reset {
+    text-decoration: none;
+    color: inherit;
+}
+
+.contributor-details-circle-image {
+    object-fit: cover;
+    border-radius: 50%;
+}
+
 @media (max-width: 480px) {
     .social-link {
         width: 32px;

--- a/src/templates/contributor-details.jsx
+++ b/src/templates/contributor-details.jsx
@@ -111,7 +111,7 @@ function ContributorDetails(props) {
                             alt='Contributor avatar'
                             width={isDesktop ? 350 : isTablet ? 300 : 250}
                             height={isDesktop ? 350 : isTablet ? 300 : 250}
-                            style={{ objectFit: 'cover', borderRadius: '50%' }}
+                            className='contributor-details-circle-image'
                         />
                     </Box>
                 </Box>
@@ -124,7 +124,7 @@ function ContributorDetails(props) {
                               : '16px 32px'
                     }
                 >
-                    <Link style={{ textDecoration: `none` }} to='/'>
+                    <Link className='contributor-details-link-plain' to='/'>
                         <Stack direction='row' gap={1}>
                             <ArrowBackIcon />
                             <Typography>Back to Spotlight</Typography>
@@ -286,10 +286,7 @@ function ContributorDetails(props) {
                         {previous ? (
                             <Link
                                 to={previous.slug}
-                                style={{
-                                    textDecoration: 'none',
-                                    color: 'inherit',
-                                }}
+                                className='contributor-details-link-reset'
                             >
                                 <Stack
                                     direction='row'
@@ -303,10 +300,7 @@ function ContributorDetails(props) {
                                         alt={previous.title}
                                         width={44}
                                         height={44}
-                                        style={{
-                                            borderRadius: '50%',
-                                            objectFit: 'cover',
-                                        }}
+                                        className='contributor-details-circle-image'
                                     />
 
                                     <Box>
@@ -349,10 +343,7 @@ function ContributorDetails(props) {
                             >
                                 <Link
                                     to={next.slug}
-                                    style={{
-                                        textDecoration: 'none',
-                                        color: 'inherit',
-                                    }}
+                                    className='contributor-details-link-reset'
                                 >
                                     <Stack
                                         direction='row'
@@ -388,10 +379,7 @@ function ContributorDetails(props) {
                                             alt={next.title}
                                             width={44}
                                             height={44}
-                                            style={{
-                                                borderRadius: '50%',
-                                                objectFit: 'cover',
-                                            }}
+                                            className='contributor-details-circle-image'
                                         />
 
                                         <ArrowBackIcon


### PR DESCRIPTION
### Description

This PR cleans up repeated inline styles in the contributor details template and moves them into the existing stylesheet.

I noticed we were repeating the same link-reset styles and circle image styles in a few places inside the template. It worked, but it made the JSX noisier and harder to maintain. This change keeps the exact same behavior and visuals, just with cleaner structure.

### What changed:

Refactoring Summary
- Replaced repeated inline styles on Gatsby elements with reusable CSS classes:
contributor-details-link-plain
contributor-details-link-reset
- Replaced repeated inline image styles
(e.g., object-fit: cover, border-radius: 50%) with:
contributor-details-circle-image
- Added these class definitions in:
contributor-details.css
- Updated component usage in:
contributor-details.jsx

### Checklist

- [x] PR title is clear and descriptive
- [x] Changes follow project conventions
- [x] No unrelated changes included
- [x] No UI/UX change intended