### PR TITLE
Fix: Improve mobile UX by adding a “See more” option for cards

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9162,6 +9162,15 @@
                 "url": "https://github.com/fb55/domhandler?sponsor=1"
             }
         },
+        "node_modules/dompurify": {
+            "version": "3.3.3",
+            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.3.tgz",
+            "integrity": "sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==",
+            "license": "(MPL-2.0 OR Apache-2.0)",
+            "optionalDependencies": {
+                "@types/trusted-types": "^2.0.7"
+            }
+        },
         "node_modules/domutils": {
             "version": "3.2.2",
             "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",

--- a/src/Components/Contributor/ContributorsList.jsx
+++ b/src/Components/Contributor/ContributorsList.jsx
@@ -1,23 +1,75 @@
-import React from 'react';
+import React, { useRef, useState } from 'react';
+import { useTheme } from '@mui/material/styles';
+import useMediaQuery from '@mui/material/useMediaQuery';
 import ContributorCard from './ContributorCard';
 import './contributors.css';
 
 const ContributorsList = ({ contributors, darkmode }) => {
+    const theme = useTheme();
+    const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
+    const [showAll, setShowAll] = useState(false);
+    const initialMobileCount = 15;
+    const seeMore = useRef(null);
+
+    const nonFeaturedContributors = contributors.filter(
+        (contributor) => contributor?.node?.pageAttributes?.featured !== 'true'
+    );
+
+    const visibleContributors =
+        isMobile && !showAll
+            ? nonFeaturedContributors.slice(0, initialMobileCount)
+            : nonFeaturedContributors;
+
+    const handleSeeLess = () => {
+        setShowAll(false);
+        setTimeout(() => {
+            seeMore.current?.scrollIntoView({
+                behavior: 'smooth',
+                block: 'end',
+            });
+        });
+    };
+
     return (
         <div
             className={`contributors-container ${darkmode ? 'dark' : 'light'}`}
         >
-            <div className='contributors-grid'>
-                {contributors.map((contributor) =>
-                    contributor?.node?.pageAttributes?.featured ===
-                    'true' ? null : (
-                        <ContributorCard
-                            key={contributor.node.id}
-                            contributor={contributor}
-                        />
-                    )
-                )}
+            <div className='contributors-grid' ref={seeMore}>
+                {visibleContributors.map((contributor) => (
+                    <ContributorCard
+                        key={contributor.node.id}
+                        contributor={contributor}
+                    />
+                ))}
             </div>
+
+            {isMobile &&
+                !showAll &&
+                nonFeaturedContributors.length > initialMobileCount && (
+                    <div className='see-more-wrapper'>
+                        <button
+                            type='button'
+                            className='see-more-button'
+                            onClick={() => setShowAll(true)}
+                        >
+                            See more
+                        </button>
+                    </div>
+                )}
+
+            {isMobile &&
+                showAll &&
+                nonFeaturedContributors.length > initialMobileCount && (
+                    <div className='see-more-wrapper'>
+                        <button
+                            type='button'
+                            className='see-more-button'
+                            onClick={handleSeeLess}
+                        >
+                            See less
+                        </button>
+                    </div>
+                )}
         </div>
     );
 };

--- a/src/Components/Contributor/contributors.css
+++ b/src/Components/Contributor/contributors.css
@@ -375,3 +375,24 @@
     opacity: 0.75;
     font-style: italic;
 }
+
+.see-more-wrapper {
+    display: flex;
+    justify-content: center;
+    margin-top: 1.5rem;
+}
+
+.see-more-button {
+    border: 1px solid currentColor;
+    border-radius: 999px;
+    background: transparent;
+    color: inherit;
+    padding: 0.5rem 1.1rem;
+    font-size: 0.95rem;
+    font-weight: 600;
+    cursor: pointer;
+}
+
+.see-more-button:hover {
+    opacity: 0.85;
+}


### PR DESCRIPTION
### Description

This PR improves mobile UX by showing only the first 10 non-featured contributor cards initially and adding a “See more” button to reveal the rest, reducing long scrolling and initial rendering load on small screens while keeping desktop behavior unchanged.

### Fixes

Fixes #492

### Screenshots

First 10 cards + See more button

<img width="430" height="781" alt="image" src="https://github.com/user-attachments/assets/1915e5b4-6abb-4e73-9a1e-ef50ad4d4e7c" />

### Checklist

- [x] PR title is clear and descriptive
- [x] Changes follow project conventions
- [x] No unrelated changes included
- [ ] Documentation updated if needed

### Additional Context

This follows the same progressive reveal UX pattern already used in Jenkins ecosystem pages, while keeping current functionality intact and limiting impact to mobile view only.
