### PR TITLE
fix improve security for external links using 'noopener'

### DIFF
--- a/src/Components/Contributor/ContributorCard.jsx
+++ b/src/Components/Contributor/ContributorCard.jsx
@@ -167,7 +167,7 @@ const ContributorCard = ({ contributor }) => {
                                 <motion.a
                                     href={`https://github.com/${github}`}
                                     target='_blank'
-                                    rel='noreferrer'
+                                    rel='noopener noreferrer'
                                     onClick={(e) => e.stopPropagation()}
                                     variants={socialLinkVariants}
                                     custom={0}
@@ -186,7 +186,7 @@ const ContributorCard = ({ contributor }) => {
                                 <motion.a
                                     href={`https://linkedin.com/in/${linkedin}`}
                                     target='_blank'
-                                    rel='noreferrer'
+                                    rel='noopener noreferrer'
                                     onClick={(e) => e.stopPropagation()}
                                     variants={socialLinkVariants}
                                     custom={1}
@@ -205,7 +205,7 @@ const ContributorCard = ({ contributor }) => {
                                 <motion.a
                                     href={`https://x.com/${twitter}`}
                                     target='_blank'
-                                    rel='noreferrer'
+                                    rel='noopener noreferrer'
                                     onClick={(e) => e.stopPropagation()}
                                     variants={socialLinkVariants}
                                     custom={2}

--- a/src/Components/Search/SearchResults.jsx
+++ b/src/Components/Search/SearchResults.jsx
@@ -72,7 +72,7 @@ function SearchResults({ results, darkmode }) {
                                         <motion.a
                                             href={`https://github.com/${item.github}`}
                                             target='_blank'
-                                            rel='noreferrer'
+                                            rel='noopener noreferrer'
                                             onClick={(e) => e.stopPropagation()}
                                             variants={socialLinkVariants}
                                             custom={0}
@@ -90,7 +90,7 @@ function SearchResults({ results, darkmode }) {
                                         <motion.a
                                             href={`https://linkedin.com/in/${item?.linkedin}`}
                                             target='_blank'
-                                            rel='noreferrer'
+                                            rel='noopener noreferrer'
                                             onClick={(e) => e.stopPropagation()}
                                             variants={socialLinkVariants}
                                             custom={1}
@@ -108,7 +108,7 @@ function SearchResults({ results, darkmode }) {
                                         <motion.a
                                             href={`https://x.com/${item.twitter}`}
                                             target='_blank'
-                                            rel='noreferrer'
+                                            rel='noopener noreferrer'
                                             onClick={(e) => e.stopPropagation()}
                                             variants={socialLinkVariants}
                                             custom={2}

--- a/src/Components/ThankYouNote.jsx
+++ b/src/Components/ThankYouNote.jsx
@@ -128,7 +128,7 @@ const ThankYouNote = ({ darkmode }) => {
                                             'and '}
                                         <a
                                             target='_blank'
-                                            rel='noreferrer'
+                                            rel='noopener noreferrer'
                                             href={`https://github.com/${repo}`}
                                         >
                                             {repo?.split('/')[1]}

--- a/src/templates/contributor-details.jsx
+++ b/src/templates/contributor-details.jsx
@@ -192,7 +192,7 @@ function ContributorDetails(props) {
                             <motion.a
                                 href={`https://linkedin.com/in/${props.data.asciidoc.pageAttributes.linkedin}`}
                                 target='_blank'
-                                rel='noreferrer'
+                                rel='noopener noreferrer'
                                 onClick={(e) => e.stopPropagation()}
                                 variants={socialLinkVariants}
                                 custom={1}
@@ -208,7 +208,7 @@ function ContributorDetails(props) {
                             <motion.a
                                 href={`https://x.com/${props.data.asciidoc.pageAttributes.twitter}`}
                                 target='_blank'
-                                rel='noreferrer'
+                                rel='noopener noreferrer'
                                 onClick={(e) => e.stopPropagation()}
                                 variants={socialLinkVariants}
                                 custom={2}
@@ -226,7 +226,7 @@ function ContributorDetails(props) {
                             <motion.a
                                 href={`https://github.com/${props.data.asciidoc.pageAttributes.github}`}
                                 target='_blank'
-                                rel='noreferrer'
+                                rel='noopener noreferrer'
                                 onClick={(e) => e.stopPropagation()}
                                 variants={socialLinkVariants}
                                 custom={0}
@@ -242,7 +242,7 @@ function ContributorDetails(props) {
                             <motion.a
                                 href={`mailto:${props.data.asciidoc.pageAttributes.email}`}
                                 target='_blank'
-                                rel='noreferrer'
+                                rel='noopener noreferrer'
                                 onClick={(e) => e.stopPropagation()}
                                 variants={socialLinkVariants}
                                 custom={1}


### PR DESCRIPTION
### Description 
This PR updates external links that use target='_blank' to include rel = 'noopener noreferrer'. 
----> Adding noopener ensures that the opened page cannot access the originating window via window.opener, which is a recommended security best practice when opening links in a new tab. 
### Changes Made 
Updated external links across multiple components to include the missing noopener attribute.
 #### Files modified: 
     src/Components/Contributor/ContributorCard.jsx 
     src/Components/Search/SearchResults.jsx 
     src/templates/contributor-details.jsx 
     src/Components/ThankYouNote.jsx 
 #### Change applied: 
     // Before: 
     rel='noreferrer' 
     
     // After: 
     rel='noopener noreferrer' 
 ### Reasoning 
 → Links using target="_blank" without noopener allow the opened page to access window.opener, which can potentially be misused to redirect the original page. 
 → Including noopener prevents this behavior and aligns with modern web security recommendations.
  ### Testing 
  ✔ Verified that all updated links still open correctly in a new tab 
  ✔ Confirmed window.opener is not accessible from the opened page 
  ✔ No changes to existing functionality or UI behavior 
  
  <img width="1919" height="804" alt="Screenshot 2026-03-21 105745" src="https://github.com/user-attachments/assets/615fdeae-3157-4347-b1cf-e8cdbcb07ce4" />

