### PR TITLE
remove duplicate asciidoc plugin and unused imagesdir config

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -30,14 +30,8 @@ module.exports = {
                 icon: `${__dirname}/src/images/jenkins.png`,
             },
         },
-        `gatsby-transformer-asciidoc`,
         {
             resolve: `gatsby-transformer-asciidoc`,
-            options: {
-                attributes: {
-                    imagesdir: `${__dirname}/static@`,
-                },
-            },
         },
         {
             resolve: `gatsby-omni-font-loader`,


### PR DESCRIPTION
### Description

<!-- Brief description of the changes introduced in this PR. -->
Removed duplicate gatsby-transformer-asciidoc plugin declaration and cleaned up unused imagesdir configuration in Gatsby config.

The plugin was previously declared twice, and the imagesdir attribute pointed to an invalid path (static@). After testing, it was confirmed that imagesdir is not used in the current setup, as images are served directly from the static/ directory and referenced via metadata.

### Fixes

<!-- Fixes #issue_number -->

### Screenshots (if applicable)

<!-- Add screenshots or recordings if this PR includes UI changes -->

### Checklist

- [x] PR title is clear and descriptive
- [x] Changes follow project conventions
- [x] No unrelated changes included
- [x] Documentation updated if needed

### Additional Context

<!-- Any extra information reviewers should know -->
- Verified by modifying imagesdir to a random path and confirming that image rendering was unaffected
- Ran gatsby clean, gatsby build, and served the public/ folder to validate no regressions
