### PR TITLE
Changed 'fontweight' to 'fontWeight' in Typography component

### DIFF
--- a/src/templates/contributor-details.jsx
+++ b/src/templates/contributor-details.jsx
@@ -133,7 +133,7 @@ function ContributorDetails(props) {
                     <Box sx={{ paddingBottom: 2, paddingTop: 2 }}>
                         <Typography
                             variant='h5'
-                            fontweight={500}
+                            fontWeight={500}
                             textAlign='center'
                         >
                             Contributor Spotlight


### PR DESCRIPTION
### Description

- Fixed typo from fontweight to fontWeight

### Fixes

Fixes #556 

### Screenshots (if applicable)

<img width="950" height="351" alt="image" src="https://github.com/user-attachments/assets/be3c9f54-c78e-4c33-ab20-260b80400cf3" />

(font-weight: 500 now applied)