### PR TITLE
Improve search performance with debounce

### DIFF
--- a/src/Components/Search/Search.jsx
+++ b/src/Components/Search/Search.jsx
@@ -6,6 +6,7 @@ import Fuse from 'fuse.js';
 import SearchResults from './SearchResults.jsx';
 function Search({ contributors, darkmode }) {
     const [searchQuery, setSearchQuery] = useState('');
+    const [debouncedQuery, setDebouncedQuery] = useState('');
     const [isFocused, setIsFocused] = useState(false);
     const [results, setResults] = useState([]);
     const searchInputRef = useRef(null);
@@ -45,13 +46,21 @@ function Search({ contributors, darkmode }) {
     }, [contributorsArray]);
 
     useEffect(() => {
-        if (!searchQuery.trim()) {
+        const timer = setTimeout(() => {
+            setDebouncedQuery(searchQuery);
+        }, 300);
+
+        return () => clearTimeout(timer);
+    }, [searchQuery]);
+
+    useEffect(() => {
+        if (!debouncedQuery.trim()) {
             setResults([]);
             return;
         }
-        const searched_results = idx.search(searchQuery);
+        const searched_results = idx.search(debouncedQuery);
         setResults(searched_results);
-    }, [searchQuery, idx]);
+    }, [debouncedQuery, idx]);
 
     useEffect(() => {
         const handleKeyDown = (e) => {


### PR DESCRIPTION
### Description
Search was running on every keystroke, which made typing feel a bit slow. Added a small debounce so it runs after the user pauses (~300ms). This makes it smoother without changing how search works.

### Changes
- Added debounced state
- Search now runs after a short delay instead of every keystroke
- Cleared timeout in cleanup

### Testing
- Tried typing quickly → no lag
- Search still works as expected