### PR TITLE
Fix pronoun and location fallback conditional checks

### DIFF
--- a/src/templates/contributor-details.jsx
+++ b/src/templates/contributor-details.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { graphql, Link } from 'gatsby';
 import { Box, Stack, Typography, useTheme } from '@mui/material';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
@@ -133,7 +133,7 @@ function ContributorDetails(props) {
                     <Box sx={{ paddingBottom: 2, paddingTop: 2 }}>
                         <Typography
                             variant='h5'
-                            fontWeight={500}
+                            fontweight={500}
                             textAlign='center'
                         >
                             Contributor Spotlight
@@ -153,13 +153,13 @@ function ContributorDetails(props) {
                             textAlign='center'
                             color='#0096FF'
                         >
-                            {props.data.asciidoc.pageAttributes.pronouns ??
+                            {props.data.asciidoc.pageAttributes.pronouns ||
                                 'They/them'}
                         </Typography>
                     </Box>
                     <Box sx={{ paddingBottom: 1.5 }}>
                         <Typography variant='h6' textAlign='center'>
-                            {props.data.asciidoc.pageAttributes.location ??
+                            {props.data.asciidoc.pageAttributes.location ||
                                 'World'}
                         </Typography>
                         {props.data.asciidoc.pageAttributes.firstcommit &&

--- a/src/templates/contributor-details.jsx
+++ b/src/templates/contributor-details.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { graphql, Link } from 'gatsby';
 import { Box, Stack, Typography, useTheme } from '@mui/material';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
@@ -133,7 +133,7 @@ function ContributorDetails(props) {
                     <Box sx={{ paddingBottom: 2, paddingTop: 2 }}>
                         <Typography
                             variant='h5'
-                            fontweight={500}
+                            fontWeight={500}
                             textAlign='center'
                         >
                             Contributor Spotlight


### PR DESCRIPTION
### Description

`??` operator replaced with `||` to properly display pronoun/world fallback values if the contributor's asiicdoc has no values for those fields.

### Fixes

Fixes #607 

### Screenshots (if applicable)

Despite no value in `page-pronouns`, we can see the fallback being properly applied now for pronouns:

<img width="1700" height="604" alt="image" src="https://github.com/user-attachments/assets/778683d4-eaca-4df6-ae66-52af65953287" />

And location, if we were to have no value there either:

<img width="1718" height="650" alt="image" src="https://github.com/user-attachments/assets/6fca8015-57a5-415d-aa26-3d64dfd61c88" />

### Additional Context

This PR was made under the assumption that all optional fields are always declared in .adoc files, just left blank. Which in this case we wouldn't have to differentiate null and empty string checks