### PR TITLE
Update ContributorDetails to conditionally render pronouns

### DIFF
--- a/src/templates/contributor-details.jsx
+++ b/src/templates/contributor-details.jsx
@@ -148,14 +148,21 @@ function ContributorDetails(props) {
                         >
                             {props.data.asciidoc.document.title}
                         </Typography>
-                        <Typography
-                            variant='h5'
-                            textAlign='center'
-                            color='#0096FF'
-                        >
-                            {props.data.asciidoc.pageAttributes.pronouns ??
-                                'They/them'}
-                        </Typography>
+
+                        {props.data.asciidoc.pageAttributes.pronouns &&
+                            props.data.asciidoc.pageAttributes.pronouns.trim() !==
+                                '' && (
+                                <Typography
+                                    variant='h5'
+                                    textAlign='center'
+                                    color='#0096FF'
+                                >
+                                    {
+                                        props.data.asciidoc.pageAttributes
+                                            .pronouns
+                                    }
+                                </Typography>
+                            )}
                     </Box>
                     <Box sx={{ paddingBottom: 1.5 }}>
                         <Typography variant='h6' textAlign='center'>


### PR DESCRIPTION
### Description

<!-- Brief description of the changes introduced in this PR. -->
This PR fixes an accessibility issue where contributor pages were rendering empty pronoun headings (`<h5></h5>`) instead of omitting them entirely. This violates accessibility and best practices standards for heading elements.

> Ref. https://dequeuniversity.com/rules/axe/4.11/empty-heading

Solution => Add condition if that pronouns is absent do not render the header "they/them" as default 
Modified =>  `src/templates/contributor-details.jsx` 

### Fixes

<!-- Fixes #issue_number -->
Fixes #609 

### Screenshots (if applicable)

<!-- Add screenshots or recordings if this PR includes UI changes -->
<img width="1715" height="304" alt="Image" src="https://github.com/user-attachments/assets/d0eae6db-674a-4e37-9eae-53c62c98b296" />

### Checklist

- [x] PR title is clear and descriptive
- [x] Changes follow project conventions
- [x] No unrelated changes included
- [x] Documentation updated if needed


