### PR TITLE
chore(Jenkinsfile): revert npm ci to npm install

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -40,7 +40,7 @@ pipeline {
 
     stage('Install dependencies') {
       steps {
-        sh 'npm ci'
+        sh 'npm install'
       }
     }
 


### PR DESCRIPTION
### Description

<!-- Brief description of the changes introduced in this PR. -->

Reverts npm ci change that broke production build due to package-lock.json being out of sync.

npm ci requires exact lockfile match, which isn't currently guaranteed in this repo. Reverting to npm install until lockfile is regenerated.

Ref:
-  https://github.com/jenkins-infra/helpdesk/issues/5093
- https://github.com/jenkins-infra/contributor-spotlight/pull/617/changes#r3195575531

### Fixes

<!-- Fixes #issue_number -->

- https://github.com/jenkins-infra/contributor-spotlight/pull/617/changes#r3195575531

### Screenshots (if applicable)

<!-- Add screenshots or recordings if this PR includes UI changes -->

### Checklist

- [x] PR title is clear and descriptive
- [x] Changes follow project conventions
- [x] No unrelated changes included
- [x] Documentation updated if needed

### Additional Context

<!-- Any extra information reviewers should know -->
