### PR TITLE
chore(Jenkinsfile/readme): replace npm install with npm ci

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -40,7 +40,7 @@ pipeline {
 
     stage('Install dependencies') {
       steps {
-        sh 'npm install'
+        sh 'npm ci'
       }
     }
 

--- a/README.adoc
+++ b/README.adoc
@@ -13,7 +13,7 @@ Requires Node.js (CI uses the version from packer-images agents; NodeJS 24.15)
 [source,bash]
 ----
 cd contributor-spotlight/
-npm install
+npm ci
 ----
 
 1. **Run the development environment**

--- a/updatecli/updatecli.d/nodejs.yaml
+++ b/updatecli/updatecli.d/nodejs.yaml
@@ -40,7 +40,7 @@ targets:
                 nodejs (.*)
             replacepattern: >
                 nodejs {{ source "packerImageNodeVersion" }}
-        # scmid: default
+        scmid: default
 
 actions:
     default:

--- a/updatecli/updatecli.d/nodejs.yaml
+++ b/updatecli/updatecli.d/nodejs.yaml
@@ -40,7 +40,7 @@ targets:
                 nodejs (.*)
             replacepattern: >
                 nodejs {{ source "packerImageNodeVersion" }}
-        scmid: default
+        # scmid: default
 
 actions:
     default:


### PR DESCRIPTION
### Description

Part of jenkins-infra/helpdesk#5119 enforcing `npm ci` over `npm install` across CI/CD pipelines for reproducible builds.

### Fixes

<!-- Fixes #issue_number -->

### Screenshots (if applicable)

<!-- Add screenshots or recordings if this PR includes UI changes -->

### Checklist

- [x] PR title is clear and descriptive
- [x] Changes follow project conventions
- [x] No unrelated changes included
- [x] Documentation updated if needed

### Additional Context

<!-- Any extra information reviewers should know -->
