### PR TITLE
chore(deps) support NPM `12.x` by bumping `gatsby-plugin-sharp` from `5.14.0` to `5.16.0` and `sharp` to `0.35.3`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
                 "axios": "^1.7.2",
                 "dayjs": "^1.11.10",
                 "dompurify": "^3.3.1",
+                "framer-motion": "^12.29.0",
                 "fuse.js": "^7.1.0",
                 "gatsby": "^5.16.1",
                 "gatsby-core-utils": "^4.14.0",
@@ -26,7 +27,7 @@
                 "gatsby-plugin-offline": "^6.14.0",
                 "gatsby-plugin-postcss": "^6.16.0",
                 "gatsby-plugin-react-helmet": "^6.14.0",
-                "gatsby-plugin-sharp": "^5.14.0",
+                "gatsby-plugin-sharp": "^5.16.0",
                 "gatsby-plugin-sitemap": "^6.14.0",
                 "gatsby-source-filesystem": "^5.14.0",
                 "gatsby-transformer-asciidoc": "^4.13.1",
@@ -34,11 +35,11 @@
                 "loader-utils": "^3.2.1",
                 "lodash": "^4.17.21",
                 "lucide-react": "^0.562.0",
-                "motion": "^12.29.0",
                 "papaparse": "^5.4.1",
                 "react": "19.2.4",
                 "react-dom": "19.2.4",
                 "react-helmet": "^6.1.0",
+                "sharp": "^0.35.3",
                 "slash": "^5.1.0"
             },
             "devDependencies": {
@@ -2121,6 +2122,16 @@
                 "partytown": "bin/partytown.cjs"
             }
         },
+        "node_modules/@emnapi/runtime": {
+            "version": "1.11.2",
+            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
+            "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
         "node_modules/@emotion/babel-plugin": {
             "version": "11.13.5",
             "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.13.5.tgz",
@@ -3043,6 +3054,554 @@
             "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
             "deprecated": "Use @eslint/object-schema instead",
             "license": "BSD-3-Clause"
+        },
+        "node_modules/@img/colour": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+            "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@img/sharp-darwin-arm64": {
+            "version": "0.35.3",
+            "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.3.tgz",
+            "integrity": "sha512-RMnFX7YQsMoh7lWfcM4NEHHymBX/rLuKNPVM84XE9ONPcaSCDgE7CHIHpSgPcO2xcRthgBy1HfNO319mwhIAkg==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=20.9.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-darwin-arm64": "1.3.2"
+            }
+        },
+        "node_modules/@img/sharp-darwin-x64": {
+            "version": "0.35.3",
+            "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.3.tgz",
+            "integrity": "sha512-Xo+5uFBtLN0BKqieTxiFzFPQAUlBbbH5iBKyRX/z1JrbnYsHTfKJnUfL8+p2TPXr1pXqao4eeL4Rl144uDpK9w==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=20.9.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-darwin-x64": "1.3.2"
+            }
+        },
+        "node_modules/@img/sharp-freebsd-wasm32": {
+            "version": "0.35.3",
+            "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.3.tgz",
+            "integrity": "sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "dependencies": {
+                "@img/sharp-wasm32": "0.35.3"
+            },
+            "engines": {
+                "node": ">=20.9.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-libvips-darwin-arm64": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.2.tgz",
+            "integrity": "sha512-9J6ypZFpQBj4YnePGoq/S38w6nz+vqg5WZLrLGY4YuSemdMq47GMLBPO42MzwdGwpg/agZ7xzZcFHa48xlywfg==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-libvips-darwin-x64": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.2.tgz",
+            "integrity": "sha512-m2pW1n6cns9VaubNwsZ+c3CRYjxNQWgJ5gPlnL1nbBcpkBvFm6SCFN5o0psFHI8w9n11NKhFkeEDns98tiqbEw==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-libvips-linux-arm": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.2.tgz",
+            "integrity": "sha512-1eMLzy92I4J6rmi4mAT8yC3HxOtniyGELlzGbNMLLeqe052ahFQ0h6LFq+lh5DsDIdYViIDst08abvSbcEdLXQ==",
+            "cpu": [
+                "arm"
+            ],
+            "libc": [
+                "glibc"
+            ],
+            "license": "LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-libvips-linux-arm64": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.2.tgz",
+            "integrity": "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==",
+            "cpu": [
+                "arm64"
+            ],
+            "libc": [
+                "glibc"
+            ],
+            "license": "LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-libvips-linux-ppc64": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.2.tgz",
+            "integrity": "sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw==",
+            "cpu": [
+                "ppc64"
+            ],
+            "libc": [
+                "glibc"
+            ],
+            "license": "LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-libvips-linux-riscv64": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.2.tgz",
+            "integrity": "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==",
+            "cpu": [
+                "riscv64"
+            ],
+            "libc": [
+                "glibc"
+            ],
+            "license": "LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-libvips-linux-s390x": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.2.tgz",
+            "integrity": "sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ==",
+            "cpu": [
+                "s390x"
+            ],
+            "libc": [
+                "glibc"
+            ],
+            "license": "LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-libvips-linux-x64": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.2.tgz",
+            "integrity": "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==",
+            "cpu": [
+                "x64"
+            ],
+            "libc": [
+                "glibc"
+            ],
+            "license": "LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.2.tgz",
+            "integrity": "sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw==",
+            "cpu": [
+                "arm64"
+            ],
+            "libc": [
+                "musl"
+            ],
+            "license": "LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.2.tgz",
+            "integrity": "sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ==",
+            "cpu": [
+                "x64"
+            ],
+            "libc": [
+                "musl"
+            ],
+            "license": "LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-linux-arm": {
+            "version": "0.35.3",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.3.tgz",
+            "integrity": "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==",
+            "cpu": [
+                "arm"
+            ],
+            "libc": [
+                "glibc"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=20.9.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-linux-arm": "1.3.2"
+            }
+        },
+        "node_modules/@img/sharp-linux-arm64": {
+            "version": "0.35.3",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.3.tgz",
+            "integrity": "sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "libc": [
+                "glibc"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=20.9.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-linux-arm64": "1.3.2"
+            }
+        },
+        "node_modules/@img/sharp-linux-ppc64": {
+            "version": "0.35.3",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.3.tgz",
+            "integrity": "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==",
+            "cpu": [
+                "ppc64"
+            ],
+            "libc": [
+                "glibc"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=20.9.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-linux-ppc64": "1.3.2"
+            }
+        },
+        "node_modules/@img/sharp-linux-riscv64": {
+            "version": "0.35.3",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.3.tgz",
+            "integrity": "sha512-0Eob78yjlYPfL5vMNWAW55l3R9Y6BQS/gOfe0ZcP9mEz9ohhKSt4im1hayiknXgf8AWrFqMvJcKIdmLmEe7yeQ==",
+            "cpu": [
+                "riscv64"
+            ],
+            "libc": [
+                "glibc"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=20.9.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-linux-riscv64": "1.3.2"
+            }
+        },
+        "node_modules/@img/sharp-linux-s390x": {
+            "version": "0.35.3",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.3.tgz",
+            "integrity": "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==",
+            "cpu": [
+                "s390x"
+            ],
+            "libc": [
+                "glibc"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=20.9.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-linux-s390x": "1.3.2"
+            }
+        },
+        "node_modules/@img/sharp-linux-x64": {
+            "version": "0.35.3",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.3.tgz",
+            "integrity": "sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA==",
+            "cpu": [
+                "x64"
+            ],
+            "libc": [
+                "glibc"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=20.9.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-linux-x64": "1.3.2"
+            }
+        },
+        "node_modules/@img/sharp-linuxmusl-arm64": {
+            "version": "0.35.3",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.3.tgz",
+            "integrity": "sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w==",
+            "cpu": [
+                "arm64"
+            ],
+            "libc": [
+                "musl"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=20.9.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-linuxmusl-arm64": "1.3.2"
+            }
+        },
+        "node_modules/@img/sharp-linuxmusl-x64": {
+            "version": "0.35.3",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.3.tgz",
+            "integrity": "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==",
+            "cpu": [
+                "x64"
+            ],
+            "libc": [
+                "musl"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=20.9.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-linuxmusl-x64": "1.3.2"
+            }
+        },
+        "node_modules/@img/sharp-wasm32": {
+            "version": "0.35.3",
+            "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.3.tgz",
+            "integrity": "sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w==",
+            "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+            "optional": true,
+            "dependencies": {
+                "@emnapi/runtime": "^1.11.1"
+            },
+            "engines": {
+                "node": ">=20.9.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-webcontainers-wasm32": {
+            "version": "0.35.3",
+            "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.3.tgz",
+            "integrity": "sha512-2rnq7bX3NzeR2T4YWgz8qiG4h3TSdMe+vN1iQXpJleSJ3SM5zQ8Fy2SyyXAWlbxpEZ2Y+Z4u1BePgJEYbSy80Q==",
+            "cpu": [
+                "wasm32"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "dependencies": {
+                "@img/sharp-wasm32": "0.35.3"
+            },
+            "engines": {
+                "node": ">=20.9.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-win32-arm64": {
+            "version": "0.35.3",
+            "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.3.tgz",
+            "integrity": "sha512-4bPwFdMbeC4JQ8L8LOyWp6nsHcboP5fxkp6iPOXz2Vg49R42TuMs2whkJ5OAP4/Ul035qOzy0AecOF9VOscn4w==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "Apache-2.0 AND LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=20.9.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-win32-ia32": {
+            "version": "0.35.3",
+            "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.3.tgz",
+            "integrity": "sha512-r53mXsBN6lFUDiST764SvgwUdHAqM4rPAiDzAmf4fLoB6X/rkfyTrLCg6+g17wJJiCmB3JYgHuUldCWUIRFSXw==",
+            "cpu": [
+                "ia32"
+            ],
+            "license": "Apache-2.0 AND LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": "^20.9.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-win32-x64": {
+            "version": "0.35.3",
+            "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.3.tgz",
+            "integrity": "sha512-D4y1vNeZrIIJCN+uHaWVtH86B+aCrdMYYjicy9pXHvbGZeGYLLSd3wdVuC37FxVXlU1ARsk84eKWfWMXGYEqvA==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "Apache-2.0 AND LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=20.9.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
         },
         "node_modules/@isaacs/cliui": {
             "version": "9.0.0",
@@ -7193,20 +7752,6 @@
                 "node": ">= 0.4"
             }
         },
-        "node_modules/b4a": {
-            "version": "1.8.1",
-            "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
-            "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
-            "license": "Apache-2.0",
-            "peerDependencies": {
-                "react-native-b4a": "*"
-            },
-            "peerDependenciesMeta": {
-                "react-native-b4a": {
-                    "optional": true
-                }
-            }
-        },
         "node_modules/babel-eslint": {
             "version": "10.1.0",
             "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.1.0.tgz",
@@ -7469,97 +8014,6 @@
             "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
             "license": "MIT"
         },
-        "node_modules/bare-events": {
-            "version": "2.8.2",
-            "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz",
-            "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
-            "license": "Apache-2.0",
-            "peerDependencies": {
-                "bare-abort-controller": "*"
-            },
-            "peerDependenciesMeta": {
-                "bare-abort-controller": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/bare-fs": {
-            "version": "4.7.1",
-            "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.1.tgz",
-            "integrity": "sha512-WDRsyVN52eAx/lBamKD6uyw8H4228h/x0sGGGegOamM2cd7Pag88GfMQalobXI+HaEUxpCkbKQUDOQqt9wawRw==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "bare-events": "^2.5.4",
-                "bare-path": "^3.0.0",
-                "bare-stream": "^2.6.4",
-                "bare-url": "^2.2.2",
-                "fast-fifo": "^1.3.2"
-            },
-            "engines": {
-                "bare": ">=1.16.0"
-            },
-            "peerDependencies": {
-                "bare-buffer": "*"
-            },
-            "peerDependenciesMeta": {
-                "bare-buffer": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/bare-os": {
-            "version": "3.9.1",
-            "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.9.1.tgz",
-            "integrity": "sha512-6M5XjcnsygQNPMCMPXSK379xrJFiZ/AEMNBmFEmQW8d/789VQATvriyi5r0HYTL9TkQ26rn3kgdTG3aisbrXkQ==",
-            "license": "Apache-2.0",
-            "engines": {
-                "bare": ">=1.14.0"
-            }
-        },
-        "node_modules/bare-path": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
-            "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "bare-os": "^3.0.1"
-            }
-        },
-        "node_modules/bare-stream": {
-            "version": "2.13.1",
-            "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.1.tgz",
-            "integrity": "sha512-Vp0cnjYyrEC4whYTymQ+YZi6pBpfiICZO3cfRG8sy67ZNWe951urv1x4eW1BKNngw3U+3fPYb5JQvHbCtxH7Ow==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "streamx": "^2.25.0",
-                "teex": "^1.0.1"
-            },
-            "peerDependencies": {
-                "bare-abort-controller": "*",
-                "bare-buffer": "*",
-                "bare-events": "*"
-            },
-            "peerDependenciesMeta": {
-                "bare-abort-controller": {
-                    "optional": true
-                },
-                "bare-buffer": {
-                    "optional": true
-                },
-                "bare-events": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/bare-url": {
-            "version": "2.4.3",
-            "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.3.tgz",
-            "integrity": "sha512-Kccpc7ACfXaxfeInfqKcZtW4pT5YBn1mesc4sCsun6sRwtbJ4h+sNOaksUpYEJUKfN65YWC6Bw2OJEFiKxq8nQ==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "bare-path": "^3.0.0"
-            }
-        },
         "node_modules/base-x": {
             "version": "3.0.11",
             "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.11.tgz",
@@ -7641,17 +8095,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/bl": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
-            "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-            "license": "MIT",
-            "dependencies": {
-                "buffer": "^5.5.0",
-                "inherits": "^2.0.4",
-                "readable-stream": "^3.4.0"
             }
         },
         "node_modules/bluebird": {
@@ -7774,30 +8217,6 @@
             "license": "Apache-2.0",
             "dependencies": {
                 "node-int64": "^0.4.0"
-            }
-        },
-        "node_modules/buffer": {
-            "version": "5.7.1",
-            "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-            "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ],
-            "license": "MIT",
-            "dependencies": {
-                "base64-js": "^1.3.1",
-                "ieee754": "^1.1.13"
             }
         },
         "node_modules/buffer-from": {
@@ -8150,12 +8569,6 @@
                 "node": ">= 6"
             }
         },
-        "node_modules/chownr": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-            "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-            "license": "ISC"
-        },
         "node_modules/chrome-trace-event": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.4.tgz",
@@ -8491,19 +8904,6 @@
                 "node": ">=6"
             }
         },
-        "node_modules/color": {
-            "version": "4.2.3",
-            "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
-            "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
-            "license": "MIT",
-            "dependencies": {
-                "color-convert": "^2.0.1",
-                "color-string": "^1.9.0"
-            },
-            "engines": {
-                "node": ">=12.5.0"
-            }
-        },
         "node_modules/color-convert": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -8521,16 +8921,6 @@
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
             "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
             "license": "MIT"
-        },
-        "node_modules/color-string": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
-            "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
-            "license": "MIT",
-            "dependencies": {
-                "color-name": "^1.0.0",
-                "simple-swizzle": "^0.2.2"
-            }
         },
         "node_modules/colord": {
             "version": "2.9.3",
@@ -10897,15 +11287,6 @@
                 "node": ">=0.8.x"
             }
         },
-        "node_modules/events-universal": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
-            "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "bare-events": "^2.7.0"
-            }
-        },
         "node_modules/execa": {
             "version": "5.1.1",
             "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -10927,15 +11308,6 @@
             },
             "funding": {
                 "url": "https://github.com/sindresorhus/execa?sponsor=1"
-            }
-        },
-        "node_modules/expand-template": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
-            "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
-            "license": "(MIT OR WTFPL)",
-            "engines": {
-                "node": ">=6"
             }
         },
         "node_modules/express": {
@@ -11211,12 +11583,6 @@
             "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
             "dev": true,
             "license": "Apache-2.0"
-        },
-        "node_modules/fast-fifo": {
-            "version": "1.3.2",
-            "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
-            "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
-            "license": "MIT"
         },
         "node_modules/fast-glob": {
             "version": "3.3.3",
@@ -11868,12 +12234,6 @@
             "engines": {
                 "node": ">= 0.6"
             }
-        },
-        "node_modules/fs-constants": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-            "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-            "license": "MIT"
         },
         "node_modules/fs-exists-cached": {
             "version": "1.0.0",
@@ -13267,12 +13627,6 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
-        },
-        "node_modules/github-from-package": {
-            "version": "0.0.0",
-            "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
-            "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
-            "license": "MIT"
         },
         "node_modules/glob": {
             "version": "7.2.3",
@@ -15941,12 +16295,6 @@
             "integrity": "sha512-r6lj77KlwqLhIUku9UWYes7KJtsczvolZkzp8hbaDPPaE24OmWl5s539Mytlj22siEQKosZ26qCBgda2PKwoJw==",
             "license": "MIT"
         },
-        "node_modules/mkdirp-classic": {
-            "version": "0.5.3",
-            "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
-            "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
-            "license": "MIT"
-        },
         "node_modules/moment": {
             "version": "2.30.1",
             "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
@@ -15954,32 +16302,6 @@
             "license": "MIT",
             "engines": {
                 "node": "*"
-            }
-        },
-        "node_modules/motion": {
-            "version": "12.42.2",
-            "resolved": "https://registry.npmjs.org/motion/-/motion-12.42.2.tgz",
-            "integrity": "sha512-Atvv11yUKIid41cVrRBDVX5m8tF8kNpExRSlbpt6APClhDjtwQssgFHhQzejxw7/7YYbjHSPKBVbHo05BuJT5Q==",
-            "license": "MIT",
-            "dependencies": {
-                "framer-motion": "^12.42.2",
-                "tslib": "^2.4.0"
-            },
-            "peerDependencies": {
-                "@emotion/is-prop-valid": "*",
-                "react": "^18.0.0 || ^19.0.0",
-                "react-dom": "^18.0.0 || ^19.0.0"
-            },
-            "peerDependenciesMeta": {
-                "@emotion/is-prop-valid": {
-                    "optional": true
-                },
-                "react": {
-                    "optional": true
-                },
-                "react-dom": {
-                    "optional": true
-                }
             }
         },
         "node_modules/motion-dom": {
@@ -16124,12 +16446,6 @@
                 "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
             }
         },
-        "node_modules/napi-build-utils": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
-            "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
-            "license": "MIT"
-        },
         "node_modules/natural-compare": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -16209,30 +16525,6 @@
             "dependencies": {
                 "lower-case": "^2.0.2",
                 "tslib": "^2.0.3"
-            }
-        },
-        "node_modules/node-abi": {
-            "version": "3.91.0",
-            "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.91.0.tgz",
-            "integrity": "sha512-B+S7X/GS3Un6wMICtnsNjQD7oSpVBQrZftHE6GZ1Fe9/k3XOOoqbM5DZZ0GO4x3YiSCQfrM28yj1ppplwgIsfg==",
-            "license": "MIT",
-            "dependencies": {
-                "semver": "^7.3.5"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/node-abi/node_modules/semver": {
-            "version": "7.7.4",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-            "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-            "license": "ISC",
-            "bin": {
-                "semver": "bin/semver.js"
-            },
-            "engines": {
-                "node": ">=10"
             }
         },
         "node_modules/node-addon-api": {
@@ -18044,70 +18336,6 @@
             "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
             "license": "MIT"
         },
-        "node_modules/prebuild-install": {
-            "version": "7.1.3",
-            "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
-            "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
-            "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
-            "license": "MIT",
-            "dependencies": {
-                "detect-libc": "^2.0.0",
-                "expand-template": "^2.0.3",
-                "github-from-package": "0.0.0",
-                "minimist": "^1.2.3",
-                "mkdirp-classic": "^0.5.3",
-                "napi-build-utils": "^2.0.0",
-                "node-abi": "^3.3.0",
-                "pump": "^3.0.0",
-                "rc": "^1.2.7",
-                "simple-get": "^4.0.0",
-                "tar-fs": "^2.0.0",
-                "tunnel-agent": "^0.6.0"
-            },
-            "bin": {
-                "prebuild-install": "bin.js"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/prebuild-install/node_modules/detect-libc": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
-            "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-            "license": "Apache-2.0",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/prebuild-install/node_modules/tar-fs": {
-            "version": "2.1.4",
-            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
-            "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
-            "license": "MIT",
-            "dependencies": {
-                "chownr": "^1.1.1",
-                "mkdirp-classic": "^0.5.2",
-                "pump": "^3.0.0",
-                "tar-stream": "^2.1.4"
-            }
-        },
-        "node_modules/prebuild-install/node_modules/tar-stream": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
-            "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
-            "license": "MIT",
-            "dependencies": {
-                "bl": "^4.0.3",
-                "end-of-stream": "^1.4.1",
-                "fs-constants": "^1.0.0",
-                "inherits": "^2.0.3",
-                "readable-stream": "^3.1.1"
-            },
-            "engines": {
-                "node": ">=6"
-            }
-        },
         "node_modules/prelude-ls": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -19671,26 +19899,52 @@
             "license": "MIT"
         },
         "node_modules/sharp": {
-            "version": "0.32.6",
-            "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.32.6.tgz",
-            "integrity": "sha512-KyLTWwgcR9Oe4d9HwCwNM2l7+J0dUQwn/yf7S0EnTtb0eVS4RxO0eUSvxPtzT4F3SY+C4K6fqdv/DO27sJ/v/w==",
-            "hasInstallScript": true,
+            "version": "0.35.3",
+            "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.3.tgz",
+            "integrity": "sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q==",
             "license": "Apache-2.0",
             "dependencies": {
-                "color": "^4.2.3",
-                "detect-libc": "^2.0.2",
-                "node-addon-api": "^6.1.0",
-                "prebuild-install": "^7.1.1",
-                "semver": "^7.5.4",
-                "simple-get": "^4.0.1",
-                "tar-fs": "^3.0.4",
-                "tunnel-agent": "^0.6.0"
+                "@img/colour": "^1.1.0",
+                "detect-libc": "^2.1.2",
+                "semver": "^7.8.5"
             },
             "engines": {
-                "node": ">=14.15.0"
+                "node": ">=20.9.0"
             },
             "funding": {
                 "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-darwin-arm64": "0.35.3",
+                "@img/sharp-darwin-x64": "0.35.3",
+                "@img/sharp-freebsd-wasm32": "0.35.3",
+                "@img/sharp-libvips-darwin-arm64": "1.3.2",
+                "@img/sharp-libvips-darwin-x64": "1.3.2",
+                "@img/sharp-libvips-linux-arm": "1.3.2",
+                "@img/sharp-libvips-linux-arm64": "1.3.2",
+                "@img/sharp-libvips-linux-ppc64": "1.3.2",
+                "@img/sharp-libvips-linux-riscv64": "1.3.2",
+                "@img/sharp-libvips-linux-s390x": "1.3.2",
+                "@img/sharp-libvips-linux-x64": "1.3.2",
+                "@img/sharp-libvips-linuxmusl-arm64": "1.3.2",
+                "@img/sharp-libvips-linuxmusl-x64": "1.3.2",
+                "@img/sharp-linux-arm": "0.35.3",
+                "@img/sharp-linux-arm64": "0.35.3",
+                "@img/sharp-linux-ppc64": "0.35.3",
+                "@img/sharp-linux-riscv64": "0.35.3",
+                "@img/sharp-linux-s390x": "0.35.3",
+                "@img/sharp-linux-x64": "0.35.3",
+                "@img/sharp-linuxmusl-arm64": "0.35.3",
+                "@img/sharp-linuxmusl-x64": "0.35.3",
+                "@img/sharp-webcontainers-wasm32": "0.35.3",
+                "@img/sharp-win32-arm64": "0.35.3",
+                "@img/sharp-win32-ia32": "0.35.3",
+                "@img/sharp-win32-x64": "0.35.3"
+            },
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                }
             }
         },
         "node_modules/sharp/node_modules/detect-libc": {
@@ -19702,16 +19956,10 @@
                 "node": ">=8"
             }
         },
-        "node_modules/sharp/node_modules/node-addon-api": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-6.1.0.tgz",
-            "integrity": "sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA==",
-            "license": "MIT"
-        },
         "node_modules/sharp/node_modules/semver": {
-            "version": "7.7.4",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-            "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+            "version": "7.8.5",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+            "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
             "license": "ISC",
             "bin": {
                 "semver": "bin/semver.js"
@@ -19836,66 +20084,6 @@
             "resolved": "https://registry.npmjs.org/signedsource/-/signedsource-1.0.0.tgz",
             "integrity": "sha512-6+eerH9fEnNmi/hyM1DXcRK3pWdoMQtlkQ+ns0ntzunjKqp5i3sKCc80ym8Fib3iaYhdJUOPdhlJWj1tvge2Ww==",
             "license": "BSD-3-Clause"
-        },
-        "node_modules/simple-concat": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
-            "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ],
-            "license": "MIT"
-        },
-        "node_modules/simple-get": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
-            "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ],
-            "license": "MIT",
-            "dependencies": {
-                "decompress-response": "^6.0.0",
-                "once": "^1.3.1",
-                "simple-concat": "^1.0.0"
-            }
-        },
-        "node_modules/simple-swizzle": {
-            "version": "0.2.4",
-            "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.4.tgz",
-            "integrity": "sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==",
-            "license": "MIT",
-            "dependencies": {
-                "is-arrayish": "^0.3.1"
-            }
-        },
-        "node_modules/simple-swizzle/node_modules/is-arrayish": {
-            "version": "0.3.4",
-            "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.4.tgz",
-            "integrity": "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==",
-            "license": "MIT"
         },
         "node_modules/sisteransi": {
             "version": "1.0.5",
@@ -20220,17 +20408,6 @@
             "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
             "engines": {
                 "node": ">=10.0.0"
-            }
-        },
-        "node_modules/streamx": {
-            "version": "2.25.0",
-            "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.25.0.tgz",
-            "integrity": "sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==",
-            "license": "MIT",
-            "dependencies": {
-                "events-universal": "^1.0.0",
-                "fast-fifo": "^1.3.2",
-                "text-decoder": "^1.1.0"
             }
         },
         "node_modules/strict-uri-encode": {
@@ -20848,41 +21025,6 @@
                 "url": "https://opencollective.com/webpack"
             }
         },
-        "node_modules/tar-fs": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.2.tgz",
-            "integrity": "sha512-QGxxTxxyleAdyM3kpFs14ymbYmNFrfY+pHj7Z8FgtbZ7w2//VAgLMac7sT6nRpIHjppXO2AwwEOg0bPFVRcmXw==",
-            "license": "MIT",
-            "dependencies": {
-                "pump": "^3.0.0",
-                "tar-stream": "^3.1.5"
-            },
-            "optionalDependencies": {
-                "bare-fs": "^4.0.1",
-                "bare-path": "^3.0.0"
-            }
-        },
-        "node_modules/tar-stream": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.2.0.tgz",
-            "integrity": "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==",
-            "license": "MIT",
-            "dependencies": {
-                "b4a": "^1.6.4",
-                "bare-fs": "^4.5.5",
-                "fast-fifo": "^1.2.0",
-                "streamx": "^2.15.0"
-            }
-        },
-        "node_modules/teex": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
-            "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
-            "license": "MIT",
-            "dependencies": {
-                "streamx": "^2.12.5"
-            }
-        },
         "node_modules/temp-dir": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-2.0.0.tgz",
@@ -21007,15 +21149,6 @@
             "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
             "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
             "license": "MIT"
-        },
-        "node_modules/text-decoder": {
-            "version": "1.2.7",
-            "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
-            "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "b4a": "^1.6.4"
-            }
         },
         "node_modules/text-table": {
             "version": "0.2.0",
@@ -21240,18 +21373,6 @@
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
             "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
             "license": "0BSD"
-        },
-        "node_modules/tunnel-agent": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-            "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "safe-buffer": "^5.0.1"
-            },
-            "engines": {
-                "node": "*"
-            }
         },
         "node_modules/type": {
             "version": "2.7.3",

--- a/package.json
+++ b/package.json
@@ -27,9 +27,9 @@
         "axios": "^1.7.2",
         "dayjs": "^1.11.10",
         "dompurify": "^3.3.1",
-        "motion": "^12.29.0",
-        "gatsby": "^5.16.1",
+        "framer-motion": "^12.29.0",
         "fuse.js": "^7.1.0",
+        "gatsby": "^5.16.1",
         "gatsby-core-utils": "^4.14.0",
         "gatsby-omni-font-loader": "^2.0.2",
         "gatsby-plugin-image": "^3.14.0",
@@ -37,7 +37,7 @@
         "gatsby-plugin-offline": "^6.14.0",
         "gatsby-plugin-postcss": "^6.16.0",
         "gatsby-plugin-react-helmet": "^6.14.0",
-        "gatsby-plugin-sharp": "^5.14.0",
+        "gatsby-plugin-sharp": "^5.16.0",
         "gatsby-plugin-sitemap": "^6.14.0",
         "gatsby-source-filesystem": "^5.14.0",
         "gatsby-transformer-asciidoc": "^4.13.1",
@@ -49,6 +49,7 @@
         "react": "19.2.4",
         "react-dom": "19.2.4",
         "react-helmet": "^6.1.0",
+        "sharp": "^0.35.3",
         "slash": "^5.1.0"
     },
     "license": "MIT",
@@ -79,6 +80,7 @@
         "path-to-regexp": "~0.1.7",
         "gatsby-plugin-offline": {
             "workbox-build": "^7.4.0"
-        }
+        },
+        "sharp": "^0.35.3"
     }
 }


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/5226#issuecomment-4999380960

This PR fixes the failing builds

Note: a `npm install` command was performed after updating `package.json` to keep the package lock file in sync.
